### PR TITLE
2.4.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "moe.apex.rule34"
         minSdk 26
         targetSdk 35
-        versionCode 231
-        versionName "2.3.1"
+        versionCode 240
+        versionName "2.4.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,17 +51,17 @@ android {
 
 dependencies {
     implementation 'com.google.accompanist:accompanist-systemuicontroller:0.30.1'
-    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation platform('org.jetbrains.kotlin:kotlin-bom:1.8.22')
-    implementation 'androidx.activity:activity-compose:1.9.2'
+    implementation 'androidx.activity:activity-compose:1.9.3'
     implementation 'androidx.core:core-ktx:1.13.1'
-    implementation platform('androidx.compose:compose-bom:2024.09.02')
-    implementation 'androidx.compose.ui:ui:1.7.2'
+    implementation platform('androidx.compose:compose-bom:2024.10.00')
+    implementation 'androidx.compose.ui:ui:1.7.4'
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
     implementation 'androidx.documentfile:documentfile:1.0.1'
-    implementation 'androidx.navigation:navigation-compose:2.7.7'
+    implementation 'androidx.navigation:navigation-compose:2.8.3'
     implementation 'androidx.paging:paging-compose:3.3.2'
     implementation 'androidx.datastore:datastore-preferences:1.1.1'
     implementation 'io.coil-kt.coil3:coil-compose:3.0.0-rc01'
@@ -74,7 +74,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
-    androidTestImplementation platform('androidx.compose:compose-bom:2024.09.02')
+    androidTestImplementation platform('androidx.compose:compose-bom:2024.10.00')
     androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
     debugImplementation 'androidx.compose.ui:ui-tooling'
     debugImplementation 'androidx.compose.ui:ui-test-manifest'

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -6,7 +6,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
 import android.util.Log
-import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -116,6 +115,7 @@ import moe.apex.rule34.util.CHIP_SPACING
 import moe.apex.rule34.util.MainScreenScaffold
 import moe.apex.rule34.util.NAV_BAR_HEIGHT
 import moe.apex.rule34.util.VerticalSpacer
+import moe.apex.rule34.util.showToast
 import moe.apex.rule34.util.withoutVertical
 import soup.compose.material.motion.animation.materialSharedAxisXIn
 import soup.compose.material.motion.animation.materialSharedAxisXOut
@@ -185,7 +185,7 @@ fun HomeScreen(navController: NavController, focusRequester: FocusRequester) {
 
     fun danbooruLimitCheck(): Boolean {
         if (tagChipList.size == 2 && prefs.imageSource == ImageSource.DANBOORU) {
-            Toast.makeText(context, "Danbooru supports up to 2 tags", Toast.LENGTH_SHORT).show()
+            showToast(context, "Danbooru supports up to 2 tags")
             return false
         }
         return true
@@ -208,7 +208,7 @@ fun HomeScreen(navController: NavController, focusRequester: FocusRequester) {
                     shouldShowSuggestions = true
                 } catch (e: Exception) {
                     withContext(Dispatchers.Main) {
-                        Toast.makeText(context, "Error fetching results", Toast.LENGTH_SHORT).show()
+                        showToast(context, "Error fetching results")
                     }
                     Log.e("App", "Error fetching autocomplete results", e)
                 }
@@ -300,15 +300,17 @@ fun HomeScreen(navController: NavController, focusRequester: FocusRequester) {
 
     fun performSearch() {
         if (tagChipList.isEmpty()) {
-            Toast.makeText(
-                context,
-                "Please select some tags",
-                Toast.LENGTH_SHORT
-            ).show()
+            showToast(context, "Please select some tags")
+        } else if (prefs.ratingsFilter.isEmpty()) {
+            showToast(context, "Please select some ratings")
+        } else if (prefs.ratingsFilter.size != 4 && prefs.imageSource == ImageSource.DANBOORU) {
+            showToast(context, "Danbooru does not support rating filtering. Please enable all ratings or use a different source.")
+            // It does but it limits the number of tags to 2 and ratings are included in that limit.
         }
         else {
             val searchTags = currentSource.site.formatTagString(tagChipList)
-            navController.navigate("searchResults/${searchTags}")
+            val ratingsFilter = ImageRating.buildSearchStringFor(prefs.ratingsFilter)
+            navController.navigate("searchResults/$searchTags+$ratingsFilter}")
         }
     }
 
@@ -329,11 +331,7 @@ fun HomeScreen(navController: NavController, focusRequester: FocusRequester) {
                 shouldShowSuggestions = false
             } else {
                 if (mostRecentSuggestions.isEmpty()) {
-                    Toast.makeText(
-                        context,
-                        "No matching tags",
-                        Toast.LENGTH_SHORT
-                    ).show()
+                    showToast(context, "No matching tags")
                 }
             }
         } else {

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -48,6 +48,7 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -363,7 +364,7 @@ fun HomeScreen(navController: NavController, focusRequester: FocusRequester) {
                         },
                         placeholder = {
                             Text(
-                                text = "Search Tags",
+                                text = "Search ${prefs.imageSource.description}",
                                 style = MaterialTheme.typography.searchField
                             )
                         },
@@ -389,15 +390,14 @@ fun HomeScreen(navController: NavController, focusRequester: FocusRequester) {
                             )
                         ),
                         trailingIcon = {
-                            Icon(
-                                imageVector = Icons.Outlined.KeyboardArrowDown,
-                                contentDescription = "Filter",
-                                modifier = Modifier
-                                    .rotate(chevronRotation)
-                                    .clickable {
-                                        showRatingFilter = !showRatingFilter
-                                    }
-                            )
+                            IconButton(modifier = Modifier.rotate(chevronRotation),
+                                onClick = { showRatingFilter = !showRatingFilter }
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Outlined.KeyboardArrowDown,
+                                    contentDescription = "Filter"
+                                )
+                            }
                         }
                     )
 

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -115,6 +115,7 @@ import moe.apex.rule34.ui.theme.searchField
 import moe.apex.rule34.util.CHIP_SPACING
 import moe.apex.rule34.util.MainScreenScaffold
 import moe.apex.rule34.util.NAV_BAR_HEIGHT
+import moe.apex.rule34.util.VerticalSpacer
 import moe.apex.rule34.util.withoutVertical
 import soup.compose.material.motion.animation.materialSharedAxisXIn
 import soup.compose.material.motion.animation.materialSharedAxisXOut
@@ -362,8 +363,6 @@ fun HomeScreen(navController: NavController, focusRequester: FocusRequester) {
                                 .replace(" ", "_")
                             getSuggestions()
                         },
-                        //prefix = { Spacer(modifier = Modifier.size(8.dp)) },
-                        suffix = { Spacer(modifier = Modifier.size(8.dp)) },
                         placeholder = {
                             Text(
                                 text = "Search Tags",
@@ -417,7 +416,7 @@ fun HomeScreen(navController: NavController, focusRequester: FocusRequester) {
                     }
                 }
 
-                Spacer(Modifier.height(12.dp))
+                VerticalSpacer()
 
                 AnimatedVisibility(showRatingFilter) {
                     Row(

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -299,19 +299,17 @@ fun HomeScreen(navController: NavController, focusRequester: FocusRequester) {
         }
     }
 
-
     fun performSearch() {
         if (tagChipList.isEmpty()) {
             showToast(context, "Please select some tags")
         } else if (prefs.ratingsFilter.isEmpty()) {
             showToast(context, "Please select some ratings")
-        } else if (prefs.ratingsFilter.size != 4 && prefs.imageSource == ImageSource.DANBOORU) {
-            showToast(context, "Filtering by rating is not supported on Danbooru")
-            // It is but it limits the number of tags to 2 and ratings are included in that limit.
+        } else if (!prefs.filterRatingsLocally && prefs.ratingsFilter.size != 4 && prefs.imageSource == ImageSource.DANBOORU) {
+            showToast(context, "To filter ratings on Danbooru, enable the 'Filter ratings locally' option")
         }
         else {
             val searchTags = currentSource.site.formatTagString(tagChipList)
-            val ratingsFilter = ImageRating.buildSearchStringFor(prefs.ratingsFilter)
+            val ratingsFilter = if (prefs.filterRatingsLocally) "" else ImageRating.buildSearchStringFor(prefs.ratingsFilter)
             val searchRoute = searchTags + if (ratingsFilter.isNotEmpty()) "+$ratingsFilter" else ""
             navController.navigate("searchResults/$searchRoute")
         }

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -305,13 +305,14 @@ fun HomeScreen(navController: NavController, focusRequester: FocusRequester) {
         } else if (prefs.ratingsFilter.isEmpty()) {
             showToast(context, "Please select some ratings")
         } else if (prefs.ratingsFilter.size != 4 && prefs.imageSource == ImageSource.DANBOORU) {
-            showToast(context, "Danbooru does not support rating filtering. Please enable all ratings or use a different source.")
-            // It does but it limits the number of tags to 2 and ratings are included in that limit.
+            showToast(context, "Filtering by rating is not supported on Danbooru")
+            // It is but it limits the number of tags to 2 and ratings are included in that limit.
         }
         else {
             val searchTags = currentSource.site.formatTagString(tagChipList)
             val ratingsFilter = ImageRating.buildSearchStringFor(prefs.ratingsFilter)
-            navController.navigate("searchResults/$searchTags+$ratingsFilter}")
+            val searchRoute = searchTags + if (ratingsFilter.isNotEmpty()) "+$ratingsFilter" else ""
+            navController.navigate("searchResults/$searchRoute")
         }
     }
 

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -4,6 +4,7 @@ package moe.apex.rule34
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -100,6 +101,11 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.SingletonImageLoader
+import coil3.gif.AnimatedImageDecoder
+import coil3.gif.GifDecoder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -134,7 +140,19 @@ val Context.prefs: UserPreferencesRepository
     get() = UserPreferencesRepository(dataStore)
 
 
-class MainActivity : ComponentActivity() {
+class MainActivity : SingletonImageLoader.Factory, ComponentActivity() {
+    override fun newImageLoader(context: PlatformContext): ImageLoader {
+        return ImageLoader.Builder(context)
+            .components {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    add(AnimatedImageDecoder.Factory())
+                } else {
+                    add(GifDecoder.Factory())
+                }
+            }
+            .build()
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -455,8 +455,8 @@ fun HomeScreen(navController: NavController, focusRequester: FocusRequester) {
                     } }
                     Column(Modifier.padding(start = 32.dp)) {
                         HorizontallyScrollingChipsWithLabels(
-                            labels = listOf("Source", "Ratings"),
                             endPadding = ((16 - CHIP_SPACING).dp),
+                            labels = listOf("Source", "Ratings"),
                             content = listOf(sourceRows, ratingRows)
                         )
                     }

--- a/app/src/main/java/moe/apex/rule34/detailview/ImageGrid.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/ImageGrid.kt
@@ -1,16 +1,11 @@
 package moe.apex.rule34.detailview
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandHorizontally
-import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.calculateStartPadding
@@ -18,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -26,13 +20,8 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
-import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface

--- a/app/src/main/java/moe/apex/rule34/detailview/ImageGrid.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/ImageGrid.kt
@@ -11,13 +11,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -56,6 +53,7 @@ import moe.apex.rule34.preferences.LocalPreferences
 import moe.apex.rule34.prefs
 import moe.apex.rule34.util.CHIP_SPACING
 import moe.apex.rule34.util.FullscreenLoadingSpinner
+import moe.apex.rule34.util.NavBarHeightVerticalSpacer
 
 
 @Composable
@@ -185,12 +183,7 @@ fun ImageGrid(
         }
 
         item(span = { GridItemSpan(maxLineSpan) }) {
-            Spacer(
-                modifier = Modifier.height(
-                    WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
-                )
-            )
+            NavBarHeightVerticalSpacer()
         }
     }
 }
-

--- a/app/src/main/java/moe/apex/rule34/detailview/ImageGrid.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/ImageGrid.kt
@@ -92,25 +92,8 @@ fun ImageGrid(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         if (filterComposable != null) {
-            item(span = { GridItemSpan(maxLineSpan) } ){
-                Box(
-                    modifier = Modifier
-                        .layout { measurable, constraints ->
-                            val sidePadding =
-                                contentPadding.calculateStartPadding(layoutDirection).roundToPx()
-                            val placeable =
-                                measurable.measure(constraints.offset(horizontal = sidePadding))
-                            layout(
-                                width = placeable.width - sidePadding,
-                                height = placeable.height
-                            ) {
-                                placeable.placeRelative(0, 0)
-                            }
-                        } // https://stackoverflow.com/a/75336645
-                        .padding(bottom = 4.dp),
-                ) {
-                    filterComposable()
-                }
+            item(span = { GridItemSpan(maxLineSpan) } ) {
+                filterComposable()
             }
         } else {
             item(span = { GridItemSpan(maxLineSpan) }) {

--- a/app/src/main/java/moe/apex/rule34/detailview/ImageGrid.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/ImageGrid.kt
@@ -54,6 +54,7 @@ import moe.apex.rule34.image.Image
 import moe.apex.rule34.preferences.ImageSource
 import moe.apex.rule34.preferences.LocalPreferences
 import moe.apex.rule34.prefs
+import moe.apex.rule34.util.CHIP_SPACING
 import moe.apex.rule34.util.FullscreenLoadingSpinner
 
 
@@ -88,7 +89,7 @@ fun ImageGrid(
                 ) {
                     Row(
                         modifier = Modifier.horizontalScroll(rememberScrollState()),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        horizontalArrangement = Arrangement.spacedBy(CHIP_SPACING.dp)
                     ) {
                         for (site in ImageSource.entries) {
                             FilterChip(

--- a/app/src/main/java/moe/apex/rule34/detailview/ImageGrid.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/ImageGrid.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -30,24 +29,18 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.offset
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import moe.apex.rule34.image.Image
-import moe.apex.rule34.preferences.LocalPreferences
-import moe.apex.rule34.prefs
 import moe.apex.rule34.util.FullscreenLoadingSpinner
 import moe.apex.rule34.util.NavBarHeightVerticalSpacer
 
@@ -62,12 +55,8 @@ fun ImageGrid(
     initialLoad: (suspend () -> Unit)? = null,
     onEndReached: suspend () -> Unit = { }
 ) {
-    val preferencesRepository = LocalContext.current.prefs
-    val prefs = LocalPreferences.current
     val lazyGridState = rememberLazyGridState()
-    val scope = rememberCoroutineScope()
     var doneInitialLoad by remember { mutableStateOf(initialLoad == null) }
-    val layoutDirection = LocalLayoutDirection.current
 
     if (!doneInitialLoad) {
         LaunchedEffect(Unit) {

--- a/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
@@ -1,5 +1,6 @@
 package moe.apex.rule34.detailview
 
+import android.util.Log
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -102,19 +103,29 @@ fun SearchResults(navController: NavController, searchQuery: String) {
                 } } else null,
                 initialLoad = {
                     withContext(Dispatchers.IO) {
-                        val newImages = imageSource.loadPage(searchQuery, pageNumber)
-                        if (!allImages.addAll(newImages)) shouldKeepSearching = false
-                        pageNumber++
+                        try {
+                            val newImages = imageSource.loadPage(searchQuery, pageNumber)
+                            if (!allImages.addAll(newImages)) shouldKeepSearching = false
+                            pageNumber++
+                        } catch (e: Exception) {
+                            Log.e("SearchResults", "Error loading initial images", e)
+                            shouldKeepSearching = false
+                        }
                     }
                 }
             ) {
                 if (shouldKeepSearching) {
                     scope.launch(Dispatchers.IO) {
-                        val newImages = imageSource.loadPage(searchQuery, pageNumber)
-                        if (newImages.isNotEmpty()) {
-                            pageNumber++
-                            allImages.addAll(newImages)
-                        } else {
+                        try {
+                            val newImages = imageSource.loadPage(searchQuery, pageNumber)
+                            if (newImages.isNotEmpty()) {
+                                pageNumber++
+                                allImages.addAll(newImages)
+                            } else {
+                                shouldKeepSearching = false
+                            }
+                        } catch (e: Exception) {
+                            Log.e("SearchResults", "Error loading new images", e)
                             shouldKeepSearching = false
                         }
                     }

--- a/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
@@ -121,7 +121,7 @@ fun SearchResults(navController: NavController, searchQuery: String) {
                             val newImages = imageSource.loadPage(searchQuery, pageNumber)
                             if (newImages.isNotEmpty()) {
                                 pageNumber++
-                                allImages.addAll(newImages)
+                                allImages.addAll(newImages.filter { it !in allImages })
                             } else {
                                 shouldKeepSearching = false
                             }

--- a/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
@@ -38,8 +38,6 @@ fun SearchResults(navController: NavController, searchQuery: String) {
     val shouldShowLargeImage = remember { mutableStateOf(false) }
     var initialPage by remember { mutableIntStateOf(0) }
     val allImages = remember { mutableStateListOf<Image>() }
-    var doneInitialLoad by remember { mutableStateOf(false) }
-    var isLoading by remember { mutableStateOf(false) }
     var shouldKeepSearching by remember { mutableStateOf(true) }
     val scope = rememberCoroutineScope()
     val imageSource = LocalPreferences.current.imageSource.site

--- a/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
@@ -1,5 +1,6 @@
 package moe.apex.rule34.detailview
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -58,13 +59,13 @@ fun SearchResults(navController: NavController, searchQuery: String) {
             ImageGrid(
                 modifier = Modifier
                     .padding(padding.withoutVertical(top = false))
-                    .padding(horizontal = 16.dp)
                     .nestedScroll(scrollBehavior.nestedScrollConnection),
                 images = allImages,
                 onImageClick = { index, image ->
                     initialPage = index
                     shouldShowLargeImage.value = true
                 },
+                contentPadding = PaddingValues(top = 8.dp, start = 16.dp, end = 16.dp),
                 initialLoad = {
                     withContext(Dispatchers.IO) {
                         val newImages = imageSource.loadPage(searchQuery, pageNumber)

--- a/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
@@ -96,7 +96,6 @@ fun SearchResults(navController: NavController, searchQuery: String) {
                 contentPadding = PaddingValues(top = 8.dp, start = 16.dp, end = 16.dp),
                 filterComposable = if (filterLocally) { {
                     HorizontallyScrollingChipsWithLabels(
-                        endPadding = (16 - CHIP_SPACING).dp,
                         labels = listOf("Ratings"),
                         content = listOf(ratingRows)
                     )

--- a/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
@@ -94,9 +94,10 @@ fun SearchResults(navController: NavController, searchQuery: String) {
                     initialPage = index
                     shouldShowLargeImage.value = true
                 },
-                contentPadding = PaddingValues(top = 8.dp, start = 16.dp, end = 16.dp),
+                contentPadding = PaddingValues(top = 16.dp, start = 16.dp, end = 16.dp),
                 filterComposable = if (filterLocally) { {
                     HorizontallyScrollingChipsWithLabels(
+                        modifier = Modifier.padding(bottom = 4.dp),
                         labels = listOf("Ratings"),
                         content = listOf(ratingRows)
                     )

--- a/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
+++ b/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
@@ -26,7 +26,6 @@ import moe.apex.rule34.preferences.ImageSource
 import moe.apex.rule34.preferences.LocalPreferences
 import moe.apex.rule34.prefs
 import moe.apex.rule34.util.AnimatedVisibilityLargeImageView
-import moe.apex.rule34.util.CHIP_SPACING
 import moe.apex.rule34.util.HorizontallyScrollingChipsWithLabels
 import moe.apex.rule34.util.MainScreenScaffold
 
@@ -86,11 +85,11 @@ fun FavouritesPage(bottomBarVisibleState: MutableState<Boolean>) {
                 initialPage = index
                 shouldShowLargeImage.value = true
             },
-            contentPadding = PaddingValues(top = 8.dp, start = 16.dp, end = 16.dp),
+            contentPadding = PaddingValues(top = 16.dp, start = 16.dp, end = 16.dp),
             filterComposable = {
                 HorizontallyScrollingChipsWithLabels(
-                    endPadding = (16 - CHIP_SPACING).dp,
-                    labels = listOf("Source", "Ratings"),
+                    modifier = Modifier.padding(bottom = 4.dp),
+                    labels = listOf("Sources", "Ratings"),
                     content = chips
                 )
             }

--- a/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
+++ b/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
@@ -1,5 +1,6 @@
 package moe.apex.rule34.favourites
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
@@ -15,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.unit.dp
 import moe.apex.rule34.detailview.ImageGrid
+import moe.apex.rule34.image.ImageRating
 import moe.apex.rule34.preferences.LocalPreferences
 import moe.apex.rule34.util.AnimatedVisibilityLargeImageView
 import moe.apex.rule34.util.MainScreenScaffold
@@ -29,21 +31,27 @@ fun FavouritesPage(bottomBarVisibleState: MutableState<Boolean>) {
     val shouldShowLargeImage = remember { mutableStateOf(false) }
     var initialPage by remember { mutableIntStateOf(0) }
 
-    val images = prefs.favouriteImages.reversed().filter { it.imageSource in prefs.favouritesFilter }
+    val images = prefs.favouriteImages.reversed().filter {
+        it.imageSource in prefs.favouritesFilter
+        &&
+        if (it.metadata?.rating == null) ImageRating.UNKNOWN in prefs.favouritesRatingsFilter
+        else it.metadata.rating in prefs.favouritesRatingsFilter
+    }
 
     MainScreenScaffold("Favourite images", scrollBehavior) { padding ->
         ImageGrid(
             modifier = Modifier
                 .padding(padding)
-                .padding(horizontal = 16.dp)
                 .nestedScroll(scrollBehavior.nestedScrollConnection),
-            showFilter = true,
             images = images,
             onImageClick = { index, image ->
                 bottomBarVisibleState.value = false
                 initialPage = index
                 shouldShowLargeImage.value = true
-            }
+            },
+            contentPadding = PaddingValues(top = 8.dp, start = 16.dp, end = 16.dp),
+            showSourceFilter = true,
+            showRatingFilter = true
         )
     }
     AnimatedVisibilityLargeImageView(shouldShowLargeImage, initialPage, images, bottomBarVisibleState)

--- a/app/src/main/java/moe/apex/rule34/image/Image.kt
+++ b/app/src/main/java/moe/apex/rule34/image/Image.kt
@@ -6,6 +6,20 @@ import androidx.compose.runtime.setValue
 import kotlinx.serialization.Serializable
 import moe.apex.rule34.preferences.ImageSource
 
+
+@Serializable
+data class ImageMetadata(
+    val artist: String?,
+    val source: String?,
+    val tags: List<String>,
+    val rating: ImageRating,
+    val pixivId: Int? = null,
+) {
+    val pixivUrl: String?
+        get() = pixivId?.let { "https://www.pixiv.net/en/artworks/$it" }
+}
+
+
 @Serializable
 data class Image(
     val fileName: String,
@@ -13,7 +27,8 @@ data class Image(
     val previewUrl: String,
     val fileUrl: String,
     val sampleUrl: String,
-    val imageSource: ImageSource = ImageSource.R34 // Backwards compatibility
+    val imageSource: ImageSource = ImageSource.R34, // Backwards compatibility
+    val metadata: ImageMetadata? = null
 ) {
     val highestQualityFormatUrl = fileUrl.takeIf { it.isNotEmpty() } ?: sampleUrl
     var preferHd by mutableStateOf(false)

--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -3,6 +3,7 @@ package moe.apex.rule34.image
 import moe.apex.rule34.RequestUtil
 import moe.apex.rule34.preferences.ImageSource
 import moe.apex.rule34.tag.TagSuggestion
+import moe.apex.rule34.util.extractPixivId
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
@@ -76,7 +77,14 @@ class Rule34 : ImageBoard {
                 continue
             }
 
-            subjects.add(Image(fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.R34))
+            // Usually on R34 the "source" is the link, but sometimes it's the artist and sometimes it's blank.
+            val metaSource = e.optString("source", "").takeIf { it.isNotEmpty() }
+            val metaTags = e.getString("tags").split(" ")
+            val metaRating = ImageRating.fromString(e.getString("rating"))
+            val metaPixivId = extractPixivId(metaSource)
+            val metadata = ImageMetadata(null, metaSource, metaTags, metaRating, metaPixivId)
+
+            subjects.add(Image(fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.R34, metadata))
         }
 
         return subjects.toList()
@@ -135,7 +143,19 @@ class Danbooru : ImageBoard {
                 continue
             }
 
-            subjects.add(Image(fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.DANBOORU))
+            val metaSource = e.optString("source", "").takeIf { it.isNotEmpty() }
+            val metaArtist = e.optString("tag_string_artist", "").takeIf { it.isNotEmpty() }
+            var metaTags = e.getString("tag_string").split(" ")
+            if (metaArtist != null)
+                metaTags = metaTags
+                    .toMutableList()
+                    .minus(metaArtist)
+                    .toList()
+            val metaRating = ImageRating.fromString(e.optString("rating"))
+            val metaPixivId = e.optInt("pixiv_id").takeIf { it != 0 }
+            val metadata = ImageMetadata(metaArtist, metaSource, metaTags, metaRating, metaPixivId)
+
+            subjects.add(Image(fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.DANBOORU, metadata))
         }
 
         return subjects.toList()
@@ -190,7 +210,13 @@ class Safebooru : ImageBoard {
                 continue
             }
 
-            subjects.add(Image(fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.SAFEBOORU))
+            val metaSource = e.optString("source", "").takeIf { it.isNotEmpty() }
+            val metaTags = e.getString("tags").split(" ")
+            val metaRating = ImageRating.fromString(e.getString("rating"))
+            val metaPixivId = extractPixivId(metaSource)
+            val metadata = ImageMetadata(null, metaSource, metaTags, metaRating, metaPixivId)
+
+            subjects.add(Image(fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.SAFEBOORU, metadata))
         }
 
         return subjects.toList()
@@ -247,7 +273,13 @@ class Gelbooru : ImageBoard {
                 continue
             }
 
-            subjects.add(Image(fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.GELBOORU))
+            val metaSource = e.optString("source", "").takeIf { it.isNotEmpty() }
+            val metaTags = e.getString("tags").split(" ")
+            val metaRating = ImageRating.fromString(e.getString("rating"))
+            val metaPixivId = extractPixivId(metaSource)
+            val metadata = ImageMetadata(null, metaSource, metaTags, metaRating, metaPixivId)
+
+            subjects.add(Image(fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.GELBOORU, metadata))
         }
 
         return subjects.toList()

--- a/app/src/main/java/moe/apex/rule34/image/ImageRating.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageRating.kt
@@ -1,7 +1,6 @@
 package moe.apex.rule34.image
 
 import android.util.Log
-import moe.apex.rule34.preferences.ImageSource
 
 
 private const val FILTER_SAFE         = "-rating:safe+-rating:general+-rating:g"
@@ -21,6 +20,13 @@ enum class ImageRating(val label: String) {
        The Gelbooru help page doesn't mention "sensitive" at all but posts seem to regularly use it.
        Likewise, Safebooru seems to use both "general" and "safe" for some reason. */
     companion object {
+        private val mapping = mapOf(
+            SAFE to FILTER_SAFE,
+            SENSITIVE to FILTER_SENSITIVE,
+            QUESTIONABLE to FILTER_QUESTIONABLE,
+            EXPLICIT to FILTER_EXPLICIT
+        )
+
         fun fromString(label: String): ImageRating {
             return when (label.lowercase()) {
                 "safe", "general", "g" -> SAFE
@@ -33,19 +39,15 @@ enum class ImageRating(val label: String) {
                 }
             }
         }
-    }
 
-    /* These image boards are so inconsistent that it's actually more reliable to search by
-       unwanted tags than by wanted tags. I hate it too.
-       Danbooru and Gelbooru seem to be the only ones that use "sensitive" but there's also no real
-       harm in adding it to the filter for other sites. */
-    fun toSearchFilters(source: ImageSource): List<String> {
-        return when (this) {
-            SAFE         -> listOf(FILTER_SENSITIVE, FILTER_QUESTIONABLE, FILTER_EXPLICIT)
-            SENSITIVE    -> listOf(FILTER_SAFE, FILTER_QUESTIONABLE, FILTER_EXPLICIT)
-            QUESTIONABLE -> listOf(FILTER_SAFE, FILTER_SENSITIVE, FILTER_EXPLICIT)
-            EXPLICIT     -> listOf(FILTER_SAFE, FILTER_SENSITIVE, FILTER_QUESTIONABLE)
-            UNKNOWN      -> emptyList()
+        fun buildSearchStringFor(vararg ratings: ImageRating): String {
+            val currentFilter = mutableListOf(FILTER_SAFE, FILTER_SENSITIVE, FILTER_QUESTIONABLE, FILTER_EXPLICIT)
+            for (rating in ratings) {
+                if (rating in mapping) {
+                    currentFilter.remove(mapping[rating])
+                }
+            }
+            return currentFilter.joinToString("+")
         }
     }
 }

--- a/app/src/main/java/moe/apex/rule34/image/ImageRating.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageRating.kt
@@ -1,0 +1,51 @@
+package moe.apex.rule34.image
+
+import android.util.Log
+import moe.apex.rule34.preferences.ImageSource
+
+
+private const val FILTER_SAFE         = "-rating:safe+-rating:general+-rating:g"
+private const val FILTER_SENSITIVE    = "-rating:sensitive+-rating:s"
+private const val FILTER_QUESTIONABLE = "-rating:questionable+-rating:q"
+private const val FILTER_EXPLICIT     = "-rating:explicit+-rating:e"
+
+
+enum class ImageRating(val label: String) {
+    SAFE("Safe"),
+    SENSITIVE("Sensitive"),
+    QUESTIONABLE("Questionable"),
+    EXPLICIT("Explicit"),
+    UNKNOWN("Unknown");
+
+    /* Why are their naming schemes so inconsistent lol
+       The Gelbooru help page doesn't mention "sensitive" at all but posts seem to regularly use it.
+       Likewise, Safebooru seems to use both "general" and "safe" for some reason. */
+    companion object {
+        fun fromString(label: String): ImageRating {
+            return when (label.lowercase()) {
+                "safe", "general", "g" -> SAFE
+                "sensitive", "s"       -> SENSITIVE
+                "questionable", "q"    -> QUESTIONABLE
+                "explicit", "e"        -> EXPLICIT
+                else -> {
+                    Log.w("ImageRating", "Unknown rating label: $label")
+                    UNKNOWN
+                }
+            }
+        }
+    }
+
+    /* These image boards are so inconsistent that it's actually more reliable to search by
+       unwanted tags than by wanted tags. I hate it too.
+       Danbooru and Gelbooru seem to be the only ones that use "sensitive" but there's also no real
+       harm in adding it to the filter for other sites. */
+    fun toSearchFilters(source: ImageSource): List<String> {
+        return when (this) {
+            SAFE         -> listOf(FILTER_SENSITIVE, FILTER_QUESTIONABLE, FILTER_EXPLICIT)
+            SENSITIVE    -> listOf(FILTER_SAFE, FILTER_QUESTIONABLE, FILTER_EXPLICIT)
+            QUESTIONABLE -> listOf(FILTER_SAFE, FILTER_SENSITIVE, FILTER_EXPLICIT)
+            EXPLICIT     -> listOf(FILTER_SAFE, FILTER_SENSITIVE, FILTER_QUESTIONABLE)
+            UNKNOWN      -> emptyList()
+        }
+    }
+}

--- a/app/src/main/java/moe/apex/rule34/image/ImageRating.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageRating.kt
@@ -40,7 +40,7 @@ enum class ImageRating(val label: String) {
             }
         }
 
-        fun buildSearchStringFor(vararg ratings: ImageRating): String {
+        fun buildSearchStringFor(ratings: List<ImageRating>): String {
             val currentFilter = mutableListOf(FILTER_SAFE, FILTER_SENSITIVE, FILTER_QUESTIONABLE, FILTER_EXPLICIT)
             for (rating in ratings) {
                 if (rating in mapping) {

--- a/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
@@ -4,7 +4,6 @@ package moe.apex.rule34.largeimageview
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES
 import android.webkit.URLUtil.isValidUrl
-import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ContextualFlowRow
@@ -50,6 +49,7 @@ import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import moe.apex.rule34.image.Image
+import moe.apex.rule34.util.showToast
 import moe.apex.rule34.util.CHIP_SPACING
 import moe.apex.rule34.util.Heading
 import moe.apex.rule34.util.LargeVerticalSpacer
@@ -126,7 +126,7 @@ fun InfoSheet(image: Image, visibilityState: MutableState<Boolean>) {
                     onClick = {
                         clip.setText(AnnotatedString(tag))
                         if (SDK_INT < VERSION_CODES.TIRAMISU) { // Android 13 has its own text copied popup
-                            Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
+                            showToast(context, "Copied to clipboard")
                         }
                     },
                     label = { Text(tag) }

--- a/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
@@ -1,0 +1,168 @@
+package moe.apex.rule34.largeimageview
+
+
+import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES
+import android.webkit.URLUtil.isValidUrl
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ContextualFlowRow
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import moe.apex.rule34.image.Image
+import moe.apex.rule34.util.Heading
+
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun InfoSheet(image: Image, visibilityState: MutableState<Boolean>) {
+    if (image.metadata == null) return
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var state: SheetState? = null
+    val clip = LocalClipboardManager.current
+    var previousSheetValue by remember { mutableStateOf(SheetValue.Hidden) }
+
+    // We want to bypass the partially expanded state when closing but not when opening.
+    state = rememberModalBottomSheetState(
+        skipPartiallyExpanded = false,
+        confirmValueChange = { newValue ->
+            if (newValue == SheetValue.PartiallyExpanded ) {
+                if (previousSheetValue == SheetValue.Expanded) {
+                    scope.launch {
+                        state?.hide()
+                        visibilityState.value = false
+                    }
+                    return@rememberModalBottomSheetState false
+                } else {
+                    previousSheetValue = newValue
+                    return@rememberModalBottomSheetState true
+                }
+            }
+            else {
+                previousSheetValue = newValue
+                return@rememberModalBottomSheetState true
+            }
+        }
+    )
+
+    /* The padding and window insets allow the content to draw behind the nav bar while ensuring
+       the sheet doesn't expand to behind the status bar. */
+    ModalBottomSheet(
+        modifier = Modifier.padding(WindowInsets.statusBars.asPaddingValues()),
+        onDismissRequest = { visibilityState.value = false },
+        sheetState = state,
+        contentWindowInsets = { BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Horizontal) }
+    ) {
+        Column(Modifier.verticalScroll(rememberScrollState())) {
+            image.metadata.artist?.let {
+                Heading(text = "Artist")
+                PaddedText(it)
+                Spacer(Modifier.height(24.dp))
+            }
+            image.metadata.source?.let {
+                Heading(text = "Source")
+                if (isValidUrl(it)) PaddedUrlText(it) else PaddedText(it)
+                Spacer(Modifier.height(24.dp))
+            }
+            Heading(text = "Rating")
+            PaddedText(image.metadata.rating.label)
+            Spacer(Modifier.height(24.dp))
+            image.metadata.pixivUrl?.let {
+                Heading(text = "Pixiv URL")
+                PaddedUrlText(it)
+                Spacer(Modifier.height(24.dp))
+            }
+            Heading(text = "Tags")
+            ContextualFlowRow(
+                itemCount = image.metadata.tags.size,
+                modifier = Modifier.padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.Start),
+                verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top),
+            ) { index ->
+                val tag = image.metadata.tags[index]
+                SuggestionChip(
+                    onClick = {
+                        clip.setText(AnnotatedString(tag))
+                        if (SDK_INT < VERSION_CODES.TIRAMISU) { // Android 13 has its own text copied popup
+                            Toast.makeText(context, "Copied to clipboard", Toast.LENGTH_SHORT).show()
+                        }
+                    },
+                    label = { Text(tag) }
+                )
+            }
+            Spacer(Modifier.height(WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding() * 2))
+        }
+    }
+}
+
+
+@Composable
+private fun PaddedText(text: String) {
+    Text(
+        modifier = Modifier.padding(horizontal = 16.dp),
+        text = text
+    )
+}
+
+
+@Composable
+private fun PaddedUrlText(text: String) {
+    val annotatedString = buildAnnotatedString {
+        withLink(LinkAnnotation.Url(
+            url = text,
+            styles = TextLinkStyles(SpanStyle(
+                color = MaterialTheme.colorScheme.secondary,
+                textDecoration = TextDecoration.Underline
+            ))
+        )) {
+            append(text)
+        }
+    }
+
+    Text(
+        text = annotatedString,
+        modifier = Modifier.padding(horizontal = 16.dp)
+    )
+}

--- a/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
@@ -38,7 +38,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
@@ -51,7 +50,9 @@ import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import moe.apex.rule34.image.Image
+import moe.apex.rule34.util.CHIP_SPACING
 import moe.apex.rule34.util.Heading
+import moe.apex.rule34.util.LargeVerticalSpacer
 
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -99,27 +100,26 @@ fun InfoSheet(image: Image, visibilityState: MutableState<Boolean>) {
             image.metadata.artist?.let {
                 Heading(text = "Artist")
                 PaddedText(it)
-                Spacer(Modifier.height(24.dp))
+                LargeVerticalSpacer()
             }
             image.metadata.source?.let {
                 Heading(text = "Source")
                 if (isValidUrl(it)) PaddedUrlText(it) else PaddedText(it)
-                Spacer(Modifier.height(24.dp))
+                LargeVerticalSpacer()
             }
             Heading(text = "Rating")
             PaddedText(image.metadata.rating.label)
-            Spacer(Modifier.height(24.dp))
+            LargeVerticalSpacer()
             image.metadata.pixivUrl?.let {
                 Heading(text = "Pixiv URL")
                 PaddedUrlText(it)
-                Spacer(Modifier.height(24.dp))
+                LargeVerticalSpacer()
             }
             Heading(text = "Tags")
             ContextualFlowRow(
                 itemCount = image.metadata.tags.size,
                 modifier = Modifier.padding(horizontal = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.Start),
-                verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top),
+                horizontalArrangement = Arrangement.spacedBy(CHIP_SPACING.dp, Alignment.Start)
             ) { index ->
                 val tag = image.metadata.tags[index]
                 SuggestionChip(

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -50,11 +50,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
@@ -233,8 +232,8 @@ fun LargeImageView(
                                     R.drawable.ic_hd_disabled
                                 }
                                 Icon(
-                                    ImageVector.vectorResource(id = vectorIcon),
-                                    "Toggle HD",
+                                    painter = painterResource(vectorIcon),
+                                    contentDescription = "Toggle HD",
                                     modifier = Modifier.scale(1.2F)
                                 )
                             }
@@ -246,7 +245,7 @@ fun LargeImageView(
                                     }
                                 }) {
                                     Icon(
-                                        imageVector = ImageVector.vectorResource(id = R.drawable.ic_star_filled),
+                                        painter = painterResource(R.drawable.ic_star_filled),
                                         contentDescription = "Remove from favourites"
                                     )
                                 }
@@ -258,7 +257,7 @@ fun LargeImageView(
                                     }
                                 }) {
                                     Icon(
-                                        imageVector = ImageVector.vectorResource(id = R.drawable.ic_star_hollow),
+                                        painter = painterResource(R.drawable.ic_star_hollow),
                                         contentDescription = "Add to favourites"
                                     )
                                 }
@@ -332,7 +331,7 @@ fun LargeImageView(
                                 }
                                 else {
                                     Icon(
-                                        imageVector = ImageVector.vectorResource(id = R.drawable.ic_download),
+                                        painter = painterResource(R.drawable.ic_download),
                                         contentDescription = "Save"
                                     )
                                 }

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -7,7 +7,7 @@ import android.content.res.Configuration
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
-import android.widget.Toast
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.PredictiveBackHandler
 import androidx.compose.animation.AnimatedVisibility
@@ -71,6 +71,7 @@ import moe.apex.rule34.image.Image
 import moe.apex.rule34.preferences.DataSaver
 import moe.apex.rule34.preferences.LocalPreferences
 import moe.apex.rule34.prefs
+import moe.apex.rule34.util.showToast
 import moe.apex.rule34.ui.theme.BreadboardTheme
 import moe.apex.rule34.util.FullscreenLoadingSpinner
 import moe.apex.rule34.util.MustSetLocation
@@ -241,7 +242,7 @@ fun LargeImageView(
                                 IconButton(onClick = {
                                     scope.launch {
                                         context.prefs.removeFavouriteImage(currentImage)
-                                        Toast.makeText(context, "Removed from your favourites", Toast.LENGTH_SHORT).show()
+                                        showToast(context, "Removed from your favourites")
                                     }
                                 }) {
                                     Icon(
@@ -253,7 +254,7 @@ fun LargeImageView(
                                 IconButton(onClick = {
                                     scope.launch {
                                         context.prefs.addFavouriteImage(currentImage)
-                                        Toast.makeText(context, "Added to your favourites", Toast.LENGTH_SHORT).show()
+                                        showToast(context, "Added to your favourites")
                                     }
                                 }) {
                                     Icon(
@@ -302,11 +303,7 @@ fun LargeImageView(
                                             )
 
                                             if (result.isSuccess) {
-                                                Toast.makeText(
-                                                    context,
-                                                    "Image saved.",
-                                                    Toast.LENGTH_SHORT
-                                                ).show()
+                                                showToast(context, "Image saved.")
                                             } else {
                                                 val exc = result.exceptionOrNull()!!
                                                 exc.printStackTrace()
@@ -314,11 +311,8 @@ fun LargeImageView(
                                                 if (exc is MustSetLocation) {
                                                     storageLocationPromptLaunched.value = true
                                                 }
-                                                Toast.makeText(
-                                                    context,
-                                                    exc.message,
-                                                    Toast.LENGTH_LONG
-                                                ).show()
+                                                showToast(context, exc.message ?: "Unknown error")
+                                                Log.e("Downloader", exc.message ?: "Error downloading image", exc)
                                             }
                                             isDownloading = false
                                         }

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -57,7 +58,6 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
-import coil3.compose.AsyncImage
 import coil3.compose.SubcomposeAsyncImage
 import coil3.gif.AnimatedImageDecoder
 import coil3.gif.GifDecoder
@@ -347,13 +347,13 @@ fun LargeImageView(
                 userScrollEnabled = canChangePage,
                 beyondViewportPageCount = 1
             ) { index ->
-                val currentImg = allImages[index]
+                val imageAtIndex = allImages[index]
 
-                if (currentImg.hdQualityOverride == null) {
+                if (imageAtIndex.hdQualityOverride == null) {
                     when (dataSaver) {
-                        DataSaver.ON -> currentImg.preferHd = false
-                        DataSaver.OFF -> currentImg.preferHd = true
-                        DataSaver.AUTO -> currentImg.preferHd = isUsingWifi
+                        DataSaver.ON -> imageAtIndex.preferHd = false
+                        DataSaver.OFF -> imageAtIndex.preferHd = true
+                        DataSaver.AUTO -> imageAtIndex.preferHd = isUsingWifi
                     }
                 }
 
@@ -370,10 +370,18 @@ fun LargeImageView(
                             .padding(bottom = NAV_BAR_HEIGHT.dp),
                         contentAlignment = Alignment.Center
                     ) {
-                        if (currentImg.preferHd) {
-                            LargeImage(imageUrl = currentImg.highestQualityFormatUrl, previewImageUrl = currentImg.previewUrl)
-                        } else {
-                            LargeImage(imageUrl = currentImg.sampleUrl, previewImageUrl = currentImg.previewUrl)
+                        key(allImages[index]) {
+                            if (imageAtIndex.preferHd) {
+                                LargeImage(
+                                    imageUrl = imageAtIndex.highestQualityFormatUrl,
+                                    previewImageUrl = imageAtIndex.previewUrl
+                                )
+                            } else {
+                                LargeImage(
+                                    imageUrl = imageAtIndex.sampleUrl,
+                                    previewImageUrl = imageAtIndex.previewUrl
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.content.res.Configuration
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
-import android.os.Build
 import android.util.Log
 import androidx.activity.compose.PredictiveBackHandler
 import androidx.compose.animation.AnimatedVisibility
@@ -40,7 +39,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -55,10 +53,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import coil3.ImageLoader
 import coil3.compose.SubcomposeAsyncImage
-import coil3.gif.AnimatedImageDecoder
-import coil3.gif.GifDecoder
 import coil3.request.ImageRequest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -109,17 +104,6 @@ fun LargeImageView(
     val isUsingWifi = isUsingWiFi(context)
     val storageLocationPromptLaunched = remember { mutableStateOf(false) }
     var isDownloading by remember { mutableStateOf(false) }
-    val loader = remember {
-        ImageLoader.Builder(context)
-            .components {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    add(AnimatedImageDecoder.Factory())
-                } else {
-                    add(GifDecoder.Factory())
-                }
-            }
-            .build()
-    }
 
     if (allImages.isEmpty()) {
         visible.value = false
@@ -172,14 +156,13 @@ fun LargeImageView(
         Suggestions welcome.
         */
 
-        val model = remember {
+        val model =
             ImageRequest.Builder(context)
                 .data(imageUrl)
                 .build()
-        }
+
         SubcomposeAsyncImage(
             model = model,
-            imageLoader = loader,
             contentDescription = "Image",
             loading = { Box(
                 modifier = modifier,
@@ -360,19 +343,11 @@ fun LargeImageView(
                             .padding(bottom = NAV_BAR_HEIGHT.dp),
                         contentAlignment = Alignment.Center
                     ) {
-                        key(allImages[index]) {
-                            if (imageAtIndex.preferHd) {
-                                LargeImage(
-                                    imageUrl = imageAtIndex.highestQualityFormatUrl,
-                                    previewImageUrl = imageAtIndex.previewUrl
-                                )
-                            } else {
-                                LargeImage(
-                                    imageUrl = imageAtIndex.sampleUrl,
-                                    previewImageUrl = imageAtIndex.previewUrl
-                                )
-                            }
-                        }
+                        LargeImage(
+                            imageUrl = if (imageAtIndex.preferHd) imageAtIndex.highestQualityFormatUrl
+                                       else imageAtIndex.sampleUrl,
+                            previewImageUrl = imageAtIndex.previewUrl
+                        )
                     }
                 }
             }

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FloatingActionButton
@@ -132,6 +133,7 @@ fun LargeImageView(
     }
 
     val currentImage = allImages[pagerState.currentPage]
+    val popupVisibilityState = remember { mutableStateOf(false) }
 
     val prefs = LocalPreferences.current
     val dataSaver = prefs.dataSaver
@@ -142,6 +144,10 @@ fun LargeImageView(
     // the default back button behaviour so we don't get taken to the home page.
     BackHandler(visible.value) {
         visible.value = false
+    }
+
+    if (popupVisibilityState.value) {
+        InfoSheet(currentImage, popupVisibilityState)
     }
 
     PredictiveBackHandler(visible.value) { progress ->
@@ -273,6 +279,16 @@ fun LargeImageView(
                                     "Share"
                                 )
                             }
+                            if (currentImage.metadata != null) {
+                                IconButton(
+                                    onClick = { popupVisibilityState.value = true }
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Outlined.Info,
+                                        contentDescription = "Info"
+                                    )
+                                }
+                            }
                         },
                         floatingActionButton = {
                             FloatingActionButton(
@@ -330,7 +346,7 @@ fun LargeImageView(
                 state = pagerState,
                 userScrollEnabled = canChangePage,
                 beyondViewportPageCount = 1
-            ) {index ->
+            ) { index ->
                 val currentImg = allImages[index]
 
                 if (currentImg.hdQualityOverride == null) {

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -8,7 +8,6 @@ import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
 import android.util.Log
-import androidx.activity.compose.BackHandler
 import androidx.activity.compose.PredictiveBackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
@@ -140,14 +139,12 @@ fun LargeImageView(
     val storageLocation = prefs.storageLocation
     val favouriteImages = prefs.favouriteImages
 
-    // Large image view is an overlay rather than a new screen entirely so we need to override
-    // the default back button behaviour so we don't get taken to the home page.
-    BackHandler(visible.value) {
-        visible.value = false
-    }
-
     if (popupVisibilityState.value) {
         InfoSheet(currentImage, popupVisibilityState)
+    }
+
+    LaunchedEffect(visible.value) {
+        if (visible.value) offset = 0.dp
     }
 
     PredictiveBackHandler(visible.value) { progress ->

--- a/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
@@ -53,6 +53,7 @@ data object PrefNames {
     const val LAST_USED_VERSION_CODE = "last_used_version_code"
     const val RATINGS_FILTER = "ratings_filter"
     const val FAVOURITES_RATING_FILTER = "favourites_rating_filter"
+    const val FILTER_RATINGS_LOCALLY = "filter_ratings_locally"
 }
 
 
@@ -73,17 +74,20 @@ data class Prefs(
     val lastUsedVersionCode: Int,
     val ratingsFilter: List<ImageRating>,
     val favouritesRatingsFilter: List<ImageRating>,
+    val filterRatingsLocally: Boolean
 ) {
     companion object {
         val DEFAULT = Prefs(
             DataSaver.AUTO,
             Uri.EMPTY,
             emptyList(),
-            false, ImageSource.SAFEBOORU,
+            false,
+            ImageSource.SAFEBOORU,
             ImageSource.entries.toList(),
             0, // We'll update this later
             listOf(ImageRating.SAFE),
             listOf(ImageRating.SAFE),
+            false,
         )
     }
 }
@@ -100,6 +104,7 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
         val LAST_USED_VERSION_CODE = intPreferencesKey(PrefNames.LAST_USED_VERSION_CODE)
         val RATINGS_FILTER = stringSetPreferencesKey(PrefNames.RATINGS_FILTER)
         val FAVOURITES_RATING_FILTER = stringSetPreferencesKey(PrefNames.FAVOURITES_RATING_FILTER)
+        val FILTER_RATINGS_LOCALLY = booleanPreferencesKey(PrefNames.FILTER_RATINGS_LOCALLY)
     }
 
     val getPreferences: Flow<Prefs> = dataStore.data
@@ -251,6 +256,12 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
         updateFavouritesRatingFilter(ratings)
     }
 
+    suspend fun updateFilterRatingsLocally(to: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[PreferenceKeys.FILTER_RATINGS_LOCALLY] = to
+        }
+    }
+
 
     @OptIn(ExperimentalSerializationApi::class)
     private fun mapUserPreferences(preferences: Preferences): Prefs {
@@ -272,6 +283,9 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
         val favouritesRatingFilter = (
             preferences[PreferenceKeys.FAVOURITES_RATING_FILTER]?.map { ImageRating.valueOf(it) } ?: listOf(ImageRating.SAFE)
         )
+        val filterRatingsLocally = (
+            preferences[PreferenceKeys.FILTER_RATINGS_LOCALLY] ?: false
+        )
 
         return Prefs(
             dataSaver,
@@ -283,6 +297,7 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
             lastUsedVersionCode,
             ratingsFilter,
             favouritesRatingFilter,
+            filterRatingsLocally,
         )
     }
 

--- a/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
@@ -254,6 +254,14 @@ fun PreferencesScreen() {
                 ) {
                     scope.launch { preferencesRepository.updateExcludeAi(it) }
                 }
+                SwitchPref(
+                    checked = currentSettings.filterRatingsLocally,
+                    title = "Filter ratings locally",
+                    summary = "Rather than appending the selected ratings to the search query, " +
+                              "filter the results by rating after searching."
+                ) {
+                    scope.launch { preferencesRepository.updateFilterRatingsLocally(it) }
+                }
 
                 HorizontalDivider(Modifier.padding(vertical = 48.dp))
 
@@ -264,12 +272,17 @@ fun PreferencesScreen() {
                         LargeVerticalSpacer()
                         InfoSection(
                             text = "Danbooru limits searches to 2 tags (which includes ratings), " +
-                                    "so filtering by rating is not possible. Remember to enable all " +
-                                    "ratings if you're using Danbooru, or consider using a different " +
-                                    "source."
+                                    "so filtering by rating is difficult. If you are using " +
+                                    "Danbooru, you should enable 'Filter ratings locally' if " +
+                                    "you wish to filter by rating."
                         )
                     }
                 }
+                LargeVerticalSpacer()
+                InfoSection(text = "Filtering ratings locally has the benefit of being able to " +
+                                   "adjust the filter after searching and allows filtering on " +
+                                   "otherwise unsupported sites like Danbooru, but may cause " +
+                                   "less results to be shown at once.")
                 NavBarHeightVerticalSpacer()
             }
         }

--- a/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
@@ -282,7 +282,8 @@ fun PreferencesScreen() {
                 InfoSection(text = "Filtering ratings locally has the benefit of being able to " +
                                    "adjust the filter after searching and allows filtering on " +
                                    "otherwise unsupported sites like Danbooru, but may cause " +
-                                   "less results to be shown at once.")
+                                   "less results to be shown at once and result in higher data "+
+                                   "usage for the same number of visible images.")
                 NavBarHeightVerticalSpacer()
             }
         }

--- a/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
@@ -45,22 +45,9 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import moe.apex.rule34.prefs
 import moe.apex.rule34.ui.theme.BreadboardTheme
+import moe.apex.rule34.util.Heading
 import moe.apex.rule34.util.MainScreenScaffold
 import moe.apex.rule34.util.SaveDirectorySelection
-
-
-@Composable
-private fun Heading(
-    modifier: Modifier = Modifier,
-    text: String
-) {
-    Text(
-        modifier = modifier.padding(horizontal = 16.dp),
-        text = text,
-        color = MaterialTheme.colorScheme.primary,
-        style = MaterialTheme.typography.titleMedium
-    )
-}
 
 
 @Composable

--- a/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
@@ -1,6 +1,7 @@
 package moe.apex.rule34.preferences
 
 import android.net.Uri
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -48,6 +49,7 @@ import moe.apex.rule34.util.VerticalSpacer
 import moe.apex.rule34.util.Heading
 import moe.apex.rule34.util.LargeVerticalSpacer
 import moe.apex.rule34.util.MainScreenScaffold
+import moe.apex.rule34.util.NavBarHeightVerticalSpacer
 import moe.apex.rule34.util.SaveDirectorySelection
 
 
@@ -257,6 +259,18 @@ fun PreferencesScreen() {
 
                 InfoSection(text = "When data saver is enabled, images will load in a lower resolution " +
                                    "by default. Downloads will always be in the maximum resolution.")
+                AnimatedVisibility(currentSettings.imageSource == ImageSource.DANBOORU) {
+                    Column {
+                        LargeVerticalSpacer()
+                        InfoSection(
+                            text = "Danbooru limits searches to 2 tags (which includes ratings), " +
+                                    "so filtering by rating is not possible. Remember to enable all " +
+                                    "ratings if you're using Danbooru, or consider using a different " +
+                                    "source."
+                        )
+                    }
+                }
+                NavBarHeightVerticalSpacer()
             }
         }
     }

--- a/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -45,7 +44,9 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import moe.apex.rule34.prefs
 import moe.apex.rule34.ui.theme.BreadboardTheme
+import moe.apex.rule34.util.VerticalSpacer
 import moe.apex.rule34.util.Heading
+import moe.apex.rule34.util.LargeVerticalSpacer
 import moe.apex.rule34.util.MainScreenScaffold
 import moe.apex.rule34.util.SaveDirectorySelection
 
@@ -182,7 +183,7 @@ private fun InfoSection(text: String) {
             contentDescription = null,
             tint = Color.Gray
         )
-        Spacer(Modifier.size(12.dp))
+        VerticalSpacer()
         Summary(text = text)
     }
 }
@@ -207,7 +208,7 @@ fun PreferencesScreen() {
                     .nestedScroll(scrollBehavior.nestedScrollConnection)
                     .verticalScroll(rememberScrollState())
             ) {
-                Spacer(Modifier.height(12.dp))
+                VerticalSpacer()
 
                 Heading(text = "Data saver")
                 EnumPref(
@@ -218,7 +219,7 @@ fun PreferencesScreen() {
                     onSelection = { scope.launch { preferencesRepository.updateDataSaver(it as DataSaver) } }
                 )
 
-                Spacer(Modifier.height(24.dp))
+                LargeVerticalSpacer()
 
                 Heading(text = "Downloads")
                 TitleSummary(
@@ -233,7 +234,7 @@ fun PreferencesScreen() {
                     SaveDirectorySelection(storageLocationPromptLaunched)
                 }
 
-                Spacer(Modifier.height(24.dp))
+                LargeVerticalSpacer()
 
                 Heading(text = "Searching")
                 EnumPref(

--- a/app/src/main/java/moe/apex/rule34/ui/theme/Theme.kt
+++ b/app/src/main/java/moe/apex/rule34/ui/theme/Theme.kt
@@ -46,7 +46,7 @@ fun BreadboardTheme(
         dynamicColor: Boolean = true,
         content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
+    var colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
             val context = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
@@ -55,6 +55,7 @@ fun BreadboardTheme(
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
     }
+    colorScheme = colorScheme.copy(outline = colorScheme.outlineVariant)
     val view = LocalView.current
     val systemUiController = rememberSystemUiController()
     val darkIcons = !darkTheme

--- a/app/src/main/java/moe/apex/rule34/util/Pixiv.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Pixiv.kt
@@ -1,0 +1,9 @@
+package moe.apex.rule34.util
+
+private val PIXIV_RX = """https?://i\.pximg\.net/img-original/img/\d+/\d+/\d+/\d+/\d+/\d+/(\d+)_p0\.(png|jpg|jpeg|gif)""".toRegex()
+
+fun extractPixivId(url: String?): Int? {
+    if (url == null) return null
+    val match = PIXIV_RX.find(url)
+    return match?.groupValues?.get(1)?.toInt()?.takeIf { it != 0 }
+}

--- a/app/src/main/java/moe/apex/rule34/util/Storage.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Storage.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.provider.DocumentsContract
-import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.runtime.Composable
@@ -47,7 +46,7 @@ fun SaveDirectorySelection(storageLocationPromptLaunched: MutableState<Boolean>)
                     scope.launch(Dispatchers.IO) { preferencesRepository.updateStorageLocation(tree) }
                 }
             } else {
-                Toast.makeText(context, "Nothing selected.", Toast.LENGTH_SHORT).show()
+                showToast(context, "Nothing selected.")
             }
             storageLocationPromptLaunched.value = false
         }

--- a/app/src/main/java/moe/apex/rule34/util/Toast.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Toast.kt
@@ -1,0 +1,8 @@
+package moe.apex.rule34.util
+
+import android.content.Context
+import android.widget.Toast
+
+fun showToast(context: Context, text: String) {
+    Toast.makeText(context, text, Toast.LENGTH_SHORT).show()
+}

--- a/app/src/main/java/moe/apex/rule34/util/Ui.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Ui.kt
@@ -193,18 +193,20 @@ fun NavBarHeightVerticalSpacer() {
 
 @Composable
 fun HorizontallyScrollingChipsWithLabels(
-    labels: List<String>,
+    modifier: Modifier = Modifier,
     endPadding: Dp = 0.dp,
+    labels: List<String>,
     content: List<List<@Composable () -> Unit>>
 ) {
     if (labels.size != content.size) {
         throw IllegalArgumentException("labels and content lists must be the same size")
     }
+    if (labels.isEmpty()) return
     val rows = labels.zip(content)
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.height(CHIP_TOTAL_HEIGHT * labels.size)
+        modifier = modifier.height(CHIP_TOTAL_HEIGHT * labels.size)
     ) {
         Column(
             verticalArrangement = Arrangement.SpaceAround,

--- a/app/src/main/java/moe/apex/rule34/util/Ui.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Ui.kt
@@ -35,6 +35,7 @@ import moe.apex.rule34.largeimageview.LargeImageView
 
 
 const val NAV_BAR_HEIGHT = 80
+const val CHIP_SPACING = 10
 
 
 @Composable

--- a/app/src/main/java/moe/apex/rule34/util/Ui.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Ui.kt
@@ -7,10 +7,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -166,3 +169,12 @@ fun LargeVerticalSpacer() {
     Spacer(Modifier.height(24.dp))
 }
 
+
+@Composable
+fun NavBarHeightVerticalSpacer() {
+    Spacer(
+        modifier = Modifier.height(
+            WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+        )
+    )
+}

--- a/app/src/main/java/moe/apex/rule34/util/Ui.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Ui.kt
@@ -199,9 +199,10 @@ fun HorizontallyScrollingChipsWithLabels(
     content: List<List<@Composable () -> Unit>>
 ) {
     if (labels.size != content.size) {
-        println(labels.size)
-        println(content.size)
-        throw IllegalArgumentException("labels and content lists must be the same size")
+        throw IllegalArgumentException(
+            "labels and content lists must be the same size. " +
+            "labels: ${labels.size}, content: ${content.size}"
+        )
     }
     if (labels.isEmpty()) return
     val rows = labels.zip(content)

--- a/app/src/main/java/moe/apex/rule34/util/Ui.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Ui.kt
@@ -6,9 +6,11 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -138,6 +140,7 @@ fun MainScreenScaffold(
     }
 }
 
+
 @Composable
 fun Heading(
     modifier: Modifier = Modifier,
@@ -150,3 +153,16 @@ fun Heading(
         style = MaterialTheme.typography.titleMedium
     )
 }
+
+
+@Composable
+fun VerticalSpacer() {
+    Spacer(Modifier.height(12.dp))
+}
+
+
+@Composable
+fun LargeVerticalSpacer() {
+    Spacer(Modifier.height(24.dp))
+}
+

--- a/app/src/main/java/moe/apex/rule34/util/Ui.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Ui.kt
@@ -3,6 +3,7 @@ package moe.apex.rule34.util
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -30,9 +31,11 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.material3.VerticalDivider
+import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -40,7 +43,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.apex.rule34.image.Image
@@ -169,18 +171,21 @@ fun Heading(
 }
 
 
+/** A vertical spacer with 12dp height. */
 @Composable
 fun VerticalSpacer() {
     Spacer(Modifier.height(12.dp))
 }
 
 
+/** A vertical spacer with 24dp height. */
 @Composable
 fun LargeVerticalSpacer() {
     Spacer(Modifier.height(24.dp))
 }
 
 
+/** A vertical spacer with the height of the navigation bar. */
 @Composable
 fun NavBarHeightVerticalSpacer() {
     Spacer(
@@ -194,7 +199,6 @@ fun NavBarHeightVerticalSpacer() {
 @Composable
 fun HorizontallyScrollingChipsWithLabels(
     modifier: Modifier = Modifier,
-    endPadding: Dp = 0.dp,
     labels: List<String>,
     content: List<List<@Composable () -> Unit>>
 ) {
@@ -207,38 +211,47 @@ fun HorizontallyScrollingChipsWithLabels(
     if (labels.isEmpty()) return
     val rows = labels.zip(content)
 
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier.height(CHIP_TOTAL_HEIGHT * labels.size)
+    Surface(
+        modifier = modifier,
+        shape = MaterialTheme.shapes.large,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+        tonalElevation = 2.dp
     ) {
-        Column(
-            verticalArrangement = Arrangement.SpaceAround,
-            modifier = Modifier.fillMaxHeight(),
-        ) {
-            for (item in rows) {
-                Text(
-                    text = item.first,
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    lineHeight = MaterialTheme.typography.titleMedium.fontSize
-                )
-            }
-        }
-
-        VerticalDivider(
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
-                .height(CHIP_TOTAL_HEIGHT * labels.size - CHIP_TOTAL_VERTICAL_PADDING)
-                .padding(start = VERTICAL_DIVIDER_SPACING.dp)
-        )
+                .padding(start = 16.dp, top = 8.dp, bottom = 8.dp)
+                .height(CHIP_TOTAL_HEIGHT * labels.size)
+        ) {
+            Column(
+                verticalArrangement = Arrangement.SpaceAround,
+                modifier = Modifier.fillMaxHeight(),
+            ) {
+                for (item in rows) {
+                    Text(
+                        text = item.first,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        lineHeight = MaterialTheme.typography.titleMedium.fontSize
+                    )
+                }
+            }
 
-        Column(Modifier.horizontalScroll(rememberScrollState())) {
-            for (item in rows) {
-                Row(horizontalArrangement = Arrangement.spacedBy(CHIP_SPACING.dp)) {
-                    Spacer(Modifier.width((VERTICAL_DIVIDER_SPACING - CHIP_SPACING).dp))
-                    for (chip in item.second) {
-                        chip()
+            VerticalDivider(
+                modifier = Modifier
+                    .height(CHIP_TOTAL_HEIGHT * labels.size - CHIP_TOTAL_VERTICAL_PADDING)
+                    .padding(start = VERTICAL_DIVIDER_SPACING.dp)
+            )
+
+            Column(Modifier.horizontalScroll(rememberScrollState())) {
+                for (item in rows) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(CHIP_SPACING.dp)) {
+                        Spacer(Modifier.width((VERTICAL_DIVIDER_SPACING - CHIP_SPACING).dp))
+                        for (chip in item.second) {
+                            chip()
+                        }
+                        Spacer(Modifier.width((16 - CHIP_SPACING).dp))
                     }
-                    Spacer(Modifier.width(endPadding))
                 }
             }
         }

--- a/app/src/main/java/moe/apex/rule34/util/Ui.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Ui.kt
@@ -199,6 +199,8 @@ fun HorizontallyScrollingChipsWithLabels(
     content: List<List<@Composable () -> Unit>>
 ) {
     if (labels.size != content.size) {
+        println(labels.size)
+        println(content.size)
         throw IllegalArgumentException("labels and content lists must be the same size")
     }
     if (labels.isEmpty()) return

--- a/app/src/main/java/moe/apex/rule34/util/Ui.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Ui.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CircularProgressIndicator
@@ -16,6 +17,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -133,4 +135,17 @@ fun MainScreenScaffold(
         )
         content(newPadding)
     }
+}
+
+@Composable
+fun Heading(
+    modifier: Modifier = Modifier,
+    text: String
+) {
+    Text(
+        modifier = modifier.padding(horizontal = 16.dp),
+        text = text,
+        color = MaterialTheme.colorScheme.primary,
+        style = MaterialTheme.typography.titleMedium
+    )
 }

--- a/app/src/main/java/moe/apex/rule34/util/Ui.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Ui.kt
@@ -3,7 +3,9 @@ package moe.apex.rule34.util
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -11,14 +13,18 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
@@ -26,6 +32,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -33,6 +40,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.apex.rule34.image.Image
@@ -40,7 +48,10 @@ import moe.apex.rule34.largeimageview.LargeImageView
 
 
 const val NAV_BAR_HEIGHT = 80
-const val CHIP_SPACING = 10
+const val CHIP_SPACING = 12
+private const val VERTICAL_DIVIDER_SPACING = 32
+private val CHIP_TOTAL_VERTICAL_PADDING = 16.dp
+private val CHIP_TOTAL_HEIGHT = FilterChipDefaults.Height + 16.dp
 
 
 @Composable
@@ -177,4 +188,54 @@ fun NavBarHeightVerticalSpacer() {
             WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
         )
     )
+}
+
+
+@Composable
+fun HorizontallyScrollingChipsWithLabels(
+    labels: List<String>,
+    endPadding: Dp = 0.dp,
+    content: List<List<@Composable () -> Unit>>
+) {
+    if (labels.size != content.size) {
+        throw IllegalArgumentException("labels and content lists must be the same size")
+    }
+    val rows = labels.zip(content)
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.height(CHIP_TOTAL_HEIGHT * labels.size)
+    ) {
+        Column(
+            verticalArrangement = Arrangement.SpaceAround,
+            modifier = Modifier.fillMaxHeight(),
+        ) {
+            for (item in rows) {
+                Text(
+                    text = item.first,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    lineHeight = MaterialTheme.typography.titleMedium.fontSize
+                )
+            }
+        }
+
+        VerticalDivider(
+            modifier = Modifier
+                .height(CHIP_TOTAL_HEIGHT * labels.size - CHIP_TOTAL_VERTICAL_PADDING)
+                .padding(start = VERTICAL_DIVIDER_SPACING.dp)
+        )
+
+        Column(Modifier.horizontalScroll(rememberScrollState())) {
+            for (item in rows) {
+                Row(horizontalArrangement = Arrangement.spacedBy(CHIP_SPACING.dp)) {
+                    Spacer(Modifier.width((VERTICAL_DIVIDER_SPACING - CHIP_SPACING).dp))
+                    for (chip in item.second) {
+                        chip()
+                    }
+                    Spacer(Modifier.width(endPadding))
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/res/drawable/ic_download.xml
+++ b/app/src/main/res/drawable/ic_download.xml
@@ -1,4 +1,5 @@
-<vector android:height="24dp" android:viewportHeight="960"
-    android:viewportWidth="960" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M480,647 L287,454l43,-43 120,120v-371h60v371l120,-120 43,43 -193,193ZM220,800q-24,0 -42,-18t-18,-42v-143h60v143h520v-143h60v143q0,24 -18,42t-42,18L220,800Z"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M19,9h-4V3H9v6H5l7,7 7,-7zM5,18v2h14v-2H5z"/>
+    
 </vector>


### PR DESCRIPTION
Updates the app to version 2.4.0.
### This has the following changes
- Support for filtering images by rating.
  - This works for all searches and all favourites saved after this update (ones saved prior will have an 'Unknown' rating).
  - Danbooru limits searches to 2 tags and this makes filtering in the search query impossible. To work around this, a 'Filter ratings locally' option has also been added.
  - Existing users will have all ratings enabled by default. New users will only have 'Safe' enabled by default
- Adds an info sheet to images.
  - Open it by tapping the ℹ️ on the bottom bar in the image viewer for all search queries and on favourites saved after this update.
- Freshen up the home page UI.
- Add the ability to select image source straight from the home page.
- Various bug fixes.
- Update dependencies.
- Code cleanups.