### PR TITLE
Group post tags in InfoSheet for supported sources + more

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "moe.apex.rule34"
         minSdk 26
         targetSdk 35
-        versionCode 250
-        versionName "2.5.0"
+        versionCode 251
+        versionName "2.5.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -277,7 +277,7 @@ fun HomeScreen(navController: NavController, focusRequester: FocusRequester, vie
                 lineHeight = 17.sp
             )
 
-            tag.type?.let {
+            tag.category?.let {
                 Text(
                     modifier = Modifier.padding(horizontal = 16.dp),
                     text = it,

--- a/app/src/main/java/moe/apex/rule34/detailview/ImageGrid.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/ImageGrid.kt
@@ -130,7 +130,7 @@ fun ImageGrid(
                 else Spacer(modifier = Modifier.height(8.dp))
             }
 
-            itemsIndexed(images, key = { _, image -> image.previewUrl }) { index, image ->
+            itemsIndexed(images) { index, image ->
                 ImagePreviewContainer(image, index, onImageClick)
             }
 

--- a/app/src/main/java/moe/apex/rule34/image/Image.kt
+++ b/app/src/main/java/moe/apex/rule34/image/Image.kt
@@ -18,7 +18,7 @@ data class ImageMetadata(
     val pixivId: Int? = null,
 ) {
     val allTags: List<String>
-        get() = groupedTags.fold(emptyList()) { acc, tagGroup -> acc.plus(tagGroup.tags) }
+        get() = groupedTags.fold(emptyList()) { acc, tagGroup -> acc + tagGroup.tags }
     val pixivUrl: String?
         get() = pixivId?.let { "https://www.pixiv.net/en/artworks/$it" }
 }

--- a/app/src/main/java/moe/apex/rule34/image/Image.kt
+++ b/app/src/main/java/moe/apex/rule34/image/Image.kt
@@ -5,16 +5,20 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import kotlinx.serialization.Serializable
 import moe.apex.rule34.preferences.ImageSource
+import moe.apex.rule34.tag.TagGroup
 
 
 @Serializable
 data class ImageMetadata(
-    val artist: String?,
-    val source: String?,
-    val tags: List<String>,
+    val artist: String? = null,
+    val source: String? = null,
+    val tags: List<String>? = null, // Backwards compatibility. No longer used in newer versions
+    val groupedTags: List<TagGroup> = emptyList(),
     val rating: ImageRating,
     val pixivId: Int? = null,
 ) {
+    val allTags: List<String>
+        get() = groupedTags.fold(emptyList()) { acc, tagGroup -> acc.plus(tagGroup.tags) }
     val pixivUrl: String?
         get() = pixivId?.let { "https://www.pixiv.net/en/artworks/$it" }
 }

--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -2,6 +2,7 @@ package moe.apex.rule34.image
 
 import moe.apex.rule34.RequestUtil
 import moe.apex.rule34.preferences.ImageSource
+import moe.apex.rule34.tag.TagCategory
 import moe.apex.rule34.tag.TagSuggestion
 import moe.apex.rule34.util.extractPixivId
 import org.json.JSONArray
@@ -88,13 +89,22 @@ interface GelbooruBasedImageBoard : ImageBoard {
             if (fileFormat != "jpeg" && fileFormat != "jpg" && fileFormat != "png" && fileFormat != "gif")
                 continue
 
-            val metaSource = e.optString("source", "").takeIf { it.isNotEmpty() }
-            val metaTags = e.getString("tags").split(" ")
+            val metaSource = e.getString("source").takeIf { it.isNotEmpty() }
+            val metaGroupedTags = listOf(
+                TagCategory.GENERAL.group(e.getString("tags").split(" ")),
+            )
             val metaRating = getRatingFromString(e.getString("rating"))
             val metaPixivId = extractPixivId(metaSource)
-            val metadata = ImageMetadata(null, metaSource, metaTags, metaRating, metaPixivId)
+            val metadata = ImageMetadata(
+                source = metaSource,
+                groupedTags = metaGroupedTags,
+                rating = metaRating,
+                pixivId = metaPixivId,
+            )
 
-            images.add(Image(fileName, fileFormat, previewUrl, fileUrl, sampleUrl, source, aspectRatio, metadata))
+            images.add(
+                Image(fileName, fileFormat, previewUrl, fileUrl, sampleUrl, source, aspectRatio, metadata),
+            )
         }
 
         return images
@@ -195,19 +205,34 @@ class Danbooru : ImageBoard {
             if (fileFormat != "jpeg" && fileFormat != "jpg" && fileFormat != "png" && fileFormat != "gif")
                 continue
 
+            val tagStringArtist = e.getString("tag_string_artist")
+            val tagCharacter = e.getString("tag_string_character").split(" ")
+            val tagCopyright = e.getString("tag_string_copyright").split(" ")
+            val tagGeneral = e.getString("tag_string_general").split(" ")
+            val tagMeta = e.getString("tag_string_meta").split(" ")
+
             val metaSource = e.getString("source").takeIf { it.isNotEmpty() }
-            val metaArtist = e.getString("tag_string_artist").takeIf { it.isNotEmpty() }
-            var metaTags = e.getString("tag_string").split(" ")
-            if (metaArtist != null)
-                metaTags = metaTags
-                    .toMutableList()
-                    .minus(metaArtist)
-                    .toList()
+            val metaArtist = tagStringArtist.takeIf { it.isNotEmpty() }
+            val metaGroupedTags = listOf(
+                    TagCategory.CHARACTER.group(tagCharacter),
+                    TagCategory.COPYRIGHT.group(tagCopyright),
+                    TagCategory.GENERAL.group(tagGeneral),
+                    TagCategory.META.group(tagMeta),
+                )
+                .filter { it.tags.isNotEmpty() }
             val metaRating = getRatingFromString(e.getString("rating"))
             val metaPixivId = e.optInt("pixiv_id").takeIf { it != 0 }
-            val metadata = ImageMetadata(metaArtist, metaSource, metaTags, metaRating, metaPixivId)
+            val metadata = ImageMetadata(
+                artist = metaArtist,
+                source = metaSource,
+                groupedTags = metaGroupedTags,
+                rating = metaRating,
+                pixivId = metaPixivId,
+            )
 
-            subjects.add(Image(fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.DANBOORU, aspectRatio, metadata))
+            subjects.add(
+                Image(fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.DANBOORU, aspectRatio, metadata),
+            )
         }
 
         return subjects.toList()
@@ -267,12 +292,21 @@ class Yandere : ImageBoard {
                 continue
 
             val metaSource = e.optString("source", "").takeIf { it.isNotEmpty() }
-            val metaTags = e.getString("tags").split(" ")
+            val metaGroupedTags = listOf(
+                TagCategory.GENERAL.group(e.getString("tags").split(" ")),
+            )
             val metaRating = getRatingFromString(e.getString("rating"))
             val metaPixivId = extractPixivId(metaSource)
-            val metadata = ImageMetadata(null, metaSource, metaTags, metaRating, metaPixivId)
+            val metadata = ImageMetadata(
+                source = metaSource,
+                groupedTags = metaGroupedTags,
+                rating = metaRating,
+                pixivId = metaPixivId,
+            )
 
-            subjects.add(Image(fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.YANDERE, aspectRatio, metadata))
+            subjects.add(
+                Image(fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.YANDERE, aspectRatio, metadata),
+            )
         }
 
         return subjects.toList()

--- a/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
@@ -114,17 +114,20 @@ fun InfoSheet(image: Image, visibilityState: MutableState<Boolean>) {
                 PaddedUrlText(it)
                 LargeVerticalSpacer()
             }
-            Heading(text = "Tags")
-            ContextualFlowRow(
-                itemCount = image.metadata.tags.size,
-                modifier = Modifier.padding(horizontal = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(CHIP_SPACING.dp, Alignment.Start)
-            ) { index ->
-                val tag = image.metadata.tags[index]
-                SuggestionChip(
-                    onClick = { copyText(context, clip, tag) },
-                    label = { Text(tag) }
-                )
+            image.metadata.groupedTags.map {
+                Heading(text = it.category.label.pluralise(it.tags.size, it.category.pluralisedLabel))
+                ContextualFlowRow(
+                    itemCount = it.tags.size,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(CHIP_SPACING.dp, Alignment.Start)
+                ) { index ->
+                    val tag = it.tags[index]
+                    SuggestionChip(
+                        onClick = { copyText(context, clip, tag) },
+                        label = { Text(tag) }
+                    )
+                }
+                Spacer(modifier = Modifier.height(16.dp))
             }
             TextButton(
                 modifier = Modifier
@@ -134,8 +137,8 @@ fun InfoSheet(image: Image, visibilityState: MutableState<Boolean>) {
                     copyText(
                         context = context,
                         clipboardManager = clip,
-                        text = image.metadata.tags.joinToString(" "),
-                        message = "Copied ${image.metadata.tags.size} ${"tag".pluralise(image.metadata.tags.size,"tags")}"
+                        text = image.metadata.allTags.joinToString(" "),
+                        message = "Copied ${image.metadata.allTags.size} ${"tag".pluralise(image.metadata.allTags.size, "tags")}"
                     )
                 }
             ) {

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -216,7 +216,7 @@ fun LargeImageView(
                                     modifier = Modifier.scale(1.2F)
                                 )
                             }
-                            if (currentImage in favouriteImages) {
+                            if (favouriteImages.any { it.fileName == currentImage.fileName }) {
                                 IconButton(onClick = {
                                     scope.launch {
                                         context.prefs.removeFavouriteImage(currentImage)

--- a/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
@@ -221,7 +221,9 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
     }
 
     suspend fun removeFavouriteImage(image: Image) {
-        val images = getPreferences.first().favouriteImages.toMutableList().apply { remove(image) }
+        val images = getPreferences.first().favouriteImages.toMutableList().apply {
+            removeAll { it.fileName == image.fileName }
+        }
         updateFavouriteImages(images)
     }
 

--- a/app/src/main/java/moe/apex/rule34/tag/TagCategory.kt
+++ b/app/src/main/java/moe/apex/rule34/tag/TagCategory.kt
@@ -1,0 +1,18 @@
+package moe.apex.rule34.tag
+
+import kotlinx.serialization.Serializable
+
+enum class TagCategory(val label: String, val pluralisedLabel: String) {
+    ARTIST("Artist", "Artists"),
+    CHARACTER("Character", "Characters"),
+    COPYRIGHT("Copyright", "Copyrights"),
+    GENERAL("Tag", "Tags"),
+    META("Meta", "Meta");
+
+    fun group(tags: List<String>): TagGroup {
+        return TagGroup(this, tags)
+    }
+}
+
+@Serializable
+data class TagGroup(val category: TagCategory, val tags: List<String>)

--- a/app/src/main/java/moe/apex/rule34/tag/TagCategory.kt
+++ b/app/src/main/java/moe/apex/rule34/tag/TagCategory.kt
@@ -10,7 +10,7 @@ enum class TagCategory(val label: String, val pluralisedLabel: String) {
     META("Meta", "Meta");
 
     fun group(tags: List<String>): TagGroup {
-        return TagGroup(this, tags)
+        return TagGroup(this, tags.filter { it.isNotEmpty() })
     }
 }
 

--- a/app/src/main/java/moe/apex/rule34/tag/TagSuggestion.kt
+++ b/app/src/main/java/moe/apex/rule34/tag/TagSuggestion.kt
@@ -5,7 +5,7 @@ import java.util.Objects
 class TagSuggestion(
     val label: String,
     val value: String,
-    val type: String?,
+    val category: String?,
     val isExcluded: Boolean
 ) {
     val formattedLabel = if (isExcluded) "-$value" else value

--- a/app/src/main/java/moe/apex/rule34/util/Pixiv.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Pixiv.kt
@@ -1,6 +1,6 @@
 package moe.apex.rule34.util
 
-private val PIXIV_RX = """https?://i\.pximg\.net/img-original/img/\d+/\d+/\d+/\d+/\d+/\d+/(\d+)_p0\.(png|jpg|jpeg|gif)""".toRegex()
+private val PIXIV_RX = """https?://i\.pximg\.net/img-original/img/\d+/\d+/\d+/\d+/\d+/\d+/(\d+)_p\d+\.(png|jpg|jpeg|gif)""".toRegex()
 
 fun extractPixivId(url: String?): Int? {
     if (url == null) return null


### PR DESCRIPTION
- Fix the Pixiv regex so that it detects posts with multiple images (1b2ce65)
- Fix Danbooru and Yandere's autocomplete tag category mappings & refactor `loadAutoComplete()` to reduce redundant code (e5f04c5)
- Group tags inside info screen for supported sources (Danbooru, for now. Other sources will have all tags categorized under General) (b73e043)