### PR TITLE
Support other Moebooru-based imageboards

### DIFF
--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -265,7 +265,7 @@ interface MoebooruBasedImageBoard : ImageBoard {
             "6" to "faults",
         )
     override val imageSearchUrl
-        get() = "${baseUrl}post.json?tags=%s&page=%d=limit=100"
+        get() = "${baseUrl}post.json?tags=%s&page=%d&limit=100"
     override val firstPageIndex
         get() = 1
 

--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -253,7 +253,8 @@ object Danbooru : ImageBoard {
 
 
 interface MoebooruBasedImageBoard : ImageBoard {
-    override val autoCompleteSearchUrl get() = "${baseUrl}tag.json?limit=10&order=count&name=%s"
+    override val autoCompleteSearchUrl
+        get() = "${baseUrl}tag.json?limit=10&order=count&name=%s"
     override val autoCompleteCategoryMapping
         get() = mapOf(
             "0" to "general",
@@ -263,8 +264,10 @@ interface MoebooruBasedImageBoard : ImageBoard {
             "5" to "circle",
             "6" to "faults",
         )
-    override val imageSearchUrl get() = "${Yandere.baseUrl}post.json?tags=%s&page=%d=limit=100"
-    override val firstPageIndex get() = 1
+    override val imageSearchUrl
+        get() = "${baseUrl}post.json?tags=%s&page=%d=limit=100"
+    override val firstPageIndex
+        get() = 1
 
     fun loadPage(tags: String, page: Int, source: ImageSource): List<Image> {
         val body = RequestUtil.get(imageSearchUrl.format(tags, page)).get()
@@ -333,6 +336,7 @@ object Yandere : MoebooruBasedImageBoard {
     }
 }
 
+
 object KonachanSFW : MoebooruBasedImageBoard {
     override val baseUrl = "https://konachan.net/"
     override val aiTagName = "ai-generated" // Konachan also doesn't allow AI-generated images but this tag appears in search
@@ -341,6 +345,7 @@ object KonachanSFW : MoebooruBasedImageBoard {
         return loadPage(tags, page, ImageSource.KONACHAN_SFW)
     }
 }
+
 
 object KonachanNSFW : MoebooruBasedImageBoard {
     override val baseUrl = "https://konachan.com/"

--- a/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
@@ -28,6 +28,8 @@ import moe.apex.rule34.image.Gelbooru
 import moe.apex.rule34.image.Image
 import moe.apex.rule34.image.ImageBoard
 import moe.apex.rule34.image.ImageRating
+import moe.apex.rule34.image.KonachanNSFW
+import moe.apex.rule34.image.KonachanSFW
 import moe.apex.rule34.image.Rule34
 import moe.apex.rule34.image.Safebooru
 import moe.apex.rule34.image.Yandere
@@ -373,6 +375,8 @@ enum class ImageSource(override val description: String, val site: ImageBoard) :
     SAFEBOORU("Safebooru", Safebooru),
     DANBOORU("Danbooru", Danbooru),
     GELBOORU("Gelbooru", Gelbooru),
+    KONACHAN_SFW("Konachan (SFW)", KonachanSFW),
+    KONACHAN_NSFW("Konachan (NSFW)", KonachanNSFW),
+    R34("Rule34", Rule34),
     YANDERE("Yande.re", Yandere),
-    R34("Rule34", Rule34)
 }

--- a/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
@@ -377,6 +377,6 @@ enum class ImageSource(override val description: String, val site: ImageBoard) :
     GELBOORU("Gelbooru", Gelbooru),
     KONACHAN_SFW("Konachan (SFW)", KonachanSFW),
     KONACHAN_NSFW("Konachan (NSFW)", KonachanNSFW),
-    R34("Rule34", Rule34),
     YANDERE("Yande.re", Yandere),
+    R34("Rule34", Rule34)
 }


### PR DESCRIPTION
There's a few other imageboards (sakugabooru etc) running on Moebooru but I'm a little concerned at how big the list could get in the UI.