### PR TITLE
Add support for image board deep links

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -11,22 +11,50 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Breadboard"
-        tools:targetApi="26"
         android:windowSoftInputMode="adjustResize"
         android:enableOnBackInvokedCallback="true">
         <activity
             android:name=".MainActivity"
+            android:launchMode="singleTop"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.Breadboard">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="safebooru.org" />
+                <data android:host="gelbooru.com" />
+                <data android:host="rule34.xxx" />
+                <data android:path="/index.php" />
+                <data android:queryAdvancedPattern="id=[0-9]+" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="danbooru.donmai.us" />
+                <data android:pathPattern="/posts/.*" />
+                <data android:pathAdvancedPattern="/posts/[0-9]+" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="https" />
+                <data android:host="yande.re" />
+                <data android:pathPattern="/post/show/.*" />
+                <data android:pathAdvancedPattern="/post/show/[0-9]+" />
             </intent-filter>
         </activity>
     </application>
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,13 +15,20 @@
         android:enableOnBackInvokedCallback="true">
         <activity
             android:name=".MainActivity"
-            android:launchMode="singleTop"
+            android:taskAffinity="BreadBoard.MainActivity"
             android:exported="true"
             android:theme="@style/Theme.Breadboard">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name=".DeepLinkActivity"
+            android:taskAffinity="BreadBoard.DeepLinkActivity"
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:theme="@style/Theme.Breadboard">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
         <activity
             android:name=".DeepLinkActivity"
             android:taskAffinity="BreadBoard.DeepLinkActivity"
-            android:excludeFromRecents="true"
+            android:launchMode="singleTop"
             android:exported="true"
             android:theme="@style/Theme.Breadboard">
             <intent-filter>

--- a/app/src/main/java/moe/apex/rule34/DeepLinkActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/DeepLinkActivity.kt
@@ -1,0 +1,98 @@
+package moe.apex.rule34
+
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.datastore.preferences.preferencesDataStoreFile
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.SingletonImageLoader
+import coil3.gif.AnimatedImageDecoder
+import coil3.gif.GifDecoder
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import moe.apex.rule34.largeimageview.LargeImageView
+import moe.apex.rule34.preferences.ImageSource
+import moe.apex.rule34.preferences.LocalPreferences
+import moe.apex.rule34.ui.theme.BreadboardTheme
+import moe.apex.rule34.ui.theme.Typography
+
+
+class DeepLinkActivity : SingletonImageLoader.Factory, ComponentActivity() {
+    override fun newImageLoader(context: PlatformContext): ImageLoader {
+        return ImageLoader.Builder(context)
+            .components {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    add(AnimatedImageDecoder.Factory())
+                } else {
+                    add(GifDecoder.Factory())
+                }
+            }
+            .build()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
+
+        applicationContext.preferencesDataStoreFile("preferences")
+        runBlocking { prefs.handleMigration(applicationContext) }
+        val initialPrefs = runBlocking { prefs.getPreferences.first() }
+
+        setContent {
+            val prefs = prefs.getPreferences.collectAsState(initialPrefs).value
+            CompositionLocalProvider(LocalPreferences provides prefs) {
+                DeepLinkLargeImageView(intent.data)
+            }
+        }
+    }
+}
+
+
+@Composable
+fun DeepLinkLargeImageView(uri: Uri?) {
+    if (uri == null) return ImageNotFound()
+
+    val image = remember { ImageSource.loadImageFromUri(uri) }
+    if (image == null) return ImageNotFound()
+
+    BreadboardTheme {
+        LargeImageView(
+            mutableStateOf(true),
+            0,
+            listOf(image)
+        )
+    }
+}
+
+
+@Composable
+fun ImageNotFound() {
+    BreadboardTheme {
+        Scaffold {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "Image not found :(",
+                    style = Typography.titleLarge
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/moe/apex/rule34/DeepLinkActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/DeepLinkActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.core.util.Consumer
@@ -57,7 +58,7 @@ class DeepLinkActivity : SingletonImageLoader.Factory, ComponentActivity() {
 
         setContent {
             val prefs = prefs.getPreferences.collectAsState(initialPrefs).value
-            val uri = mutableStateOf(intent.data)
+            val uri = rememberSaveable { mutableStateOf(intent.data) }
             CompositionLocalProvider(LocalPreferences provides prefs) {
                 DisposableEffect(Unit) {
                     val listener = Consumer<Intent> { newIntent -> uri.value = newIntent.data }

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -365,8 +365,8 @@ fun HomeScreen(navController: NavController, focusRequester: FocusRequester, vie
             val searchTags = currentSource.site.formatTagString(tagChipList)
             val ratingsFilter = if (prefs.filterRatingsLocally) ""
                                 else ImageRating.buildSearchStringFor(prefs.ratingsFilter)
-            val searchRoute = searchTags + if (ratingsFilter.isNotEmpty()) "+$ratingsFilter" else ""
-            navController.navigate("searchResults/$searchRoute")
+            val searchQuery = searchTags + if (ratingsFilter.isNotEmpty()) "+$ratingsFilter" else ""
+            navController.navigate("searchResults?query=$searchQuery")
         }
     }
 
@@ -795,7 +795,7 @@ fun Navigation(navController: NavHostController, viewModel: BreadboardViewModel)
                         )
                     }
                     composable(
-                        route = "searchResults/{searchQuery}",
+                        route = "searchResults?query={searchQuery}",
                         arguments = listOf(navArgument("searchQuery") { NavType.StringType })
                     ) { navBackStackEntry ->
                         SearchResults(

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -189,7 +189,7 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity() {
                         if (uri != null) {
                             val domain = uri.host
                             val postId = uri.getQueryParameter("id") ?: uri.path?.split("/")?.last()
-                            navController.navigate("deepLink/$domain/$postId")
+                            navController.navigate("deepLink?domain=$domain&postId=$postId")
                         }
                     }
                     addOnNewIntentListener(listener)
@@ -771,7 +771,7 @@ fun Navigation(navController: NavHostController, viewModel: BreadboardViewModel)
                 ) {
                     composable("home") { HomeScreen(navController, focusRequester, viewModel) }
                     composable(
-                        route = "deepLink/{domain}/{postId}",
+                        route = "deepLink?domain={domain}&postId={postId}",
                         arguments = listOf(
                             navArgument("domain") { NavType.StringType },
                             navArgument("postId") { NavType.StringType }

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -752,7 +752,7 @@ fun Navigation(navController: NavHostController, viewModel: BreadboardViewModel)
                         )
                     }
                     composable("settings") { PreferencesScreen(viewModel) }
-                    composable("favourite_images") { FavouritesPage(navController, bottomBarVisibleState) }
+                    composable("favourite_images") { FavouritesPage(bottomBarVisibleState) }
                 }
             }
         }

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -4,7 +4,6 @@ package moe.apex.rule34
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -67,7 +66,6 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -95,7 +93,6 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.util.Consumer
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.datastore.preferences.preferencesDataStoreFile
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -107,7 +104,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import androidx.navigation.navDeepLink
 import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.SingletonImageLoader
@@ -123,7 +119,6 @@ import kotlinx.coroutines.withContext
 import moe.apex.rule34.detailview.SearchResults
 import moe.apex.rule34.favourites.FavouritesPage
 import moe.apex.rule34.image.ImageRating
-import moe.apex.rule34.largeimageview.DeepLinkLargeImageView
 import moe.apex.rule34.preferences.ImageSource
 import moe.apex.rule34.preferences.LocalPreferences
 import moe.apex.rule34.preferences.PreferencesScreen
@@ -146,8 +141,6 @@ import moe.apex.rule34.viewmodel.BreadboardViewModel
 import moe.apex.rule34.viewmodel.getIndexByName
 import soup.compose.material.motion.animation.materialSharedAxisXIn
 import soup.compose.material.motion.animation.materialSharedAxisXOut
-import soup.compose.material.motion.animation.materialSharedAxisYIn
-import soup.compose.material.motion.animation.materialSharedAxisYOut
 import soup.compose.material.motion.animation.rememberSlideDistance
 
 
@@ -182,18 +175,6 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity() {
             val prefs = prefs.getPreferences.collectAsState(initialPrefs).value
             val viewModel = viewModel(BreadboardViewModel::class.java)
             CompositionLocalProvider(LocalPreferences provides prefs) {
-                /* Handle deep links while the main activity is running.
-                   This is required since the application's launchMode is set to singleTop.*/
-                DisposableEffect(Unit) {
-                    val listener = Consumer<Intent> { intent ->
-                        val uri = intent.data
-                        if (uri != null)
-                            try { navController.navigate(uri) }
-                            catch (_: Exception) { } // Ignore the exception for invalid URIs
-                    }
-                    addOnNewIntentListener(listener)
-                    onDispose { removeOnNewIntentListener(listener) }
-                }
                 Navigation(navController, viewModel)
             }
         }
@@ -742,55 +723,25 @@ fun Navigation(navController: NavHostController, viewModel: BreadboardViewModel)
                     enterTransition = {
                         if (targetState.destination.route?.startsWith("searchResults") == true)
                             materialSharedAxisXIn(!isRtl, slideDistance)
-                        else if (targetState.destination.route?.startsWith("deepLink") == true)
-                            materialSharedAxisYIn(false, slideDistance)
                         else fadeIn()
                     },
                     exitTransition = {
                         if (targetState.destination.route?.startsWith("searchResults") == true)
                             materialSharedAxisXOut(!isRtl, slideDistance)
-                        else if (targetState.destination.route?.startsWith("deepLink") == true)
-                            materialSharedAxisYOut(false, slideDistance)
                         else fadeOut()
                     },
                     popEnterTransition = {
                         if (initialState.destination.route?.startsWith("searchResults") == true)
                             materialSharedAxisXIn(isRtl, slideDistance)
-                        else if (initialState.destination.route?.startsWith("deepLink") == true)
-                            materialSharedAxisYIn(false, slideDistance)
                         else fadeIn()
                     },
                     popExitTransition = {
                         if (initialState.destination.route?.startsWith("searchResults") == true)
                             materialSharedAxisXOut(isRtl, slideDistance)
-                        else if (initialState.destination.route?.startsWith("deepLink") == true)
-                            materialSharedAxisYOut(false, slideDistance)
                         else fadeOut()
                     }
                 ) {
                     composable("home") { HomeScreen(navController, focusRequester, viewModel) }
-                    composable(
-                        route = "deepLink?domain={domain}&postId={postId}",
-                        arguments = listOf(
-                            navArgument("domain") { NavType.StringType },
-                            navArgument("postId") { NavType.StringType }
-                        ),
-                        deepLinks = listOf(
-                            navDeepLink { uriPattern = "{domain}/index.php?id={postId}" },
-
-                            navDeepLink { uriPattern = "{domain}/posts/{postId}" },
-                            navDeepLink { uriPattern = "{domain}/posts/{postId}/.*" },
-
-                            navDeepLink { uriPattern = "{domain}/post/show/{postId}" },
-                            navDeepLink { uriPattern = "{domain}/post/show/{postId}/.*" }
-                        )
-                    ) { navBackStackEntry ->
-                        DeepLinkLargeImageView(
-                            navController,
-                            navBackStackEntry.arguments?.getString("domain"),
-                            navBackStackEntry.arguments?.getString("postId")
-                        )
-                    }
                     composable(
                         route = "searchResults?query={searchQuery}",
                         arguments = listOf(navArgument("searchQuery") { NavType.StringType })

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -182,16 +182,14 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity() {
             val prefs = prefs.getPreferences.collectAsState(initialPrefs).value
             val viewModel = viewModel(BreadboardViewModel::class.java)
             CompositionLocalProvider(LocalPreferences provides prefs) {
-                // Handle deep links while the app is running. This is required since the app's launchMode is singleTop
+                /* Handle deep links while the main activity is running.
+                   This is required since the application's launchMode is set to singleTop.*/
                 DisposableEffect(Unit) {
                     val listener = Consumer<Intent> { intent ->
                         val uri = intent.data
-                        if (uri != null) {
-                            val domain = uri.host
-                            val postId = uri.getQueryParameter("id")
-                                ?: uri.path?.trimEnd('/')?.split("/")?.last()
-                            navController.navigate("deepLink?domain=$domain&postId=$postId")
-                        }
+                        if (uri != null)
+                            try { navController.navigate(uri) }
+                            catch (_: Exception) { } // Ignore the exception for invalid URIs
                     }
                     addOnNewIntentListener(listener)
                     onDispose { removeOnNewIntentListener(listener) }

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -188,7 +188,8 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity() {
                         val uri = intent.data
                         if (uri != null) {
                             val domain = uri.host
-                            val postId = uri.getQueryParameter("id") ?: uri.path?.split("/")?.last()
+                            val postId = uri.getQueryParameter("id")
+                                ?: uri.path?.trimEnd('/')?.split("/")?.last()
                             navController.navigate("deepLink?domain=$domain&postId=$postId")
                         }
                     }
@@ -777,15 +778,13 @@ fun Navigation(navController: NavHostController, viewModel: BreadboardViewModel)
                             navArgument("postId") { NavType.StringType }
                         ),
                         deepLinks = listOf(
-                            navDeepLink {
-                                uriPattern = "https://{domain}/index.php?id={postId}"
-                            },
-                            navDeepLink {
-                                uriPattern = "https://{domain}/posts/{postId}"
-                            },
-                            navDeepLink {
-                                uriPattern = "https://{domain}/post/show/{postId}"
-                            }
+                            navDeepLink { uriPattern = "{domain}/index.php?id={postId}" },
+
+                            navDeepLink { uriPattern = "{domain}/posts/{postId}" },
+                            navDeepLink { uriPattern = "{domain}/posts/{postId}/.*" },
+
+                            navDeepLink { uriPattern = "{domain}/post/show/{postId}" },
+                            navDeepLink { uriPattern = "{domain}/post/show/{postId}/.*" }
                         )
                     ) { navBackStackEntry ->
                         DeepLinkLargeImageView(

--- a/app/src/main/java/moe/apex/rule34/detailview/ImageGrid.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/ImageGrid.kt
@@ -115,8 +115,7 @@ fun ImageGrid(
                 NavBarHeightVerticalSpacer()
             }
         }
-    }
-    else {
+    } else {
         LazyVerticalGrid(
             columns = GridCells.Adaptive(MIN_CELL_WIDTH.dp),
             state = rememberLazyGridState(),
@@ -130,7 +129,7 @@ fun ImageGrid(
                 else Spacer(modifier = Modifier.height(8.dp))
             }
 
-            itemsIndexed(images) { index, image ->
+            itemsIndexed(images, key = { _, image -> image.previewUrl }) { index, image ->
                 ImagePreviewContainer(image, index, onImageClick)
             }
 

--- a/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
@@ -88,7 +88,7 @@ fun SearchResults(navController: NavController, searchQuery: String) {
                     .padding(padding.withoutVertical(top = false))
                     .nestedScroll(scrollBehavior.nestedScrollConnection),
                 images = imagesToDisplay,
-                onImageClick = { index, image ->
+                onImageClick = { index, _ ->
                     initialPage = index
                     shouldShowLargeImage.value = true
                 },
@@ -132,5 +132,10 @@ fun SearchResults(navController: NavController, searchQuery: String) {
             }
         }
     }
-    AnimatedVisibilityLargeImageView(shouldShowLargeImage, initialPage, imagesToDisplay)
+    AnimatedVisibilityLargeImageView(
+        navController,
+        shouldShowLargeImage,
+        initialPage,
+        imagesToDisplay
+    )
 }

--- a/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
@@ -133,7 +133,6 @@ fun SearchResults(navController: NavController, searchQuery: String) {
         }
     }
     AnimatedVisibilityLargeImageView(
-        navController,
         shouldShowLargeImage,
         initialPage,
         imagesToDisplay

--- a/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
@@ -132,9 +132,5 @@ fun SearchResults(navController: NavController, searchQuery: String) {
             }
         }
     }
-    AnimatedVisibilityLargeImageView(
-        shouldShowLargeImage,
-        initialPage,
-        imagesToDisplay
-    )
+    AnimatedVisibilityLargeImageView(shouldShowLargeImage, initialPage, imagesToDisplay)
 }

--- a/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
+++ b/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
@@ -95,10 +95,5 @@ fun FavouritesPage(bottomBarVisibleState: MutableState<Boolean>) {
             }
         )
     }
-    AnimatedVisibilityLargeImageView(
-        shouldShowLargeImage,
-        initialPage,
-        images,
-        bottomBarVisibleState
-    )
+    AnimatedVisibilityLargeImageView(shouldShowLargeImage, initialPage, images, bottomBarVisibleState)
 }

--- a/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
+++ b/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
 import kotlinx.coroutines.launch
 import moe.apex.rule34.detailview.ImageGrid
 import moe.apex.rule34.image.ImageRating
@@ -33,7 +32,7 @@ import moe.apex.rule34.util.MainScreenScaffold
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun FavouritesPage(navController: NavController, bottomBarVisibleState: MutableState<Boolean>) {
+fun FavouritesPage(bottomBarVisibleState: MutableState<Boolean>) {
     val prefs = LocalPreferences.current
     val preferencesRepository = LocalContext.current.prefs
     val topAppBarState = rememberTopAppBarState()

--- a/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
+++ b/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
@@ -97,7 +97,6 @@ fun FavouritesPage(navController: NavController, bottomBarVisibleState: MutableS
         )
     }
     AnimatedVisibilityLargeImageView(
-        navController,
         shouldShowLargeImage,
         initialPage,
         images,

--- a/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
+++ b/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import kotlinx.coroutines.launch
 import moe.apex.rule34.detailview.ImageGrid
 import moe.apex.rule34.image.ImageRating
@@ -32,7 +33,7 @@ import moe.apex.rule34.util.MainScreenScaffold
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun FavouritesPage(bottomBarVisibleState: MutableState<Boolean>) {
+fun FavouritesPage(navController: NavController, bottomBarVisibleState: MutableState<Boolean>) {
     val prefs = LocalPreferences.current
     val preferencesRepository = LocalContext.current.prefs
     val topAppBarState = rememberTopAppBarState()
@@ -80,7 +81,7 @@ fun FavouritesPage(bottomBarVisibleState: MutableState<Boolean>) {
                 .padding(padding)
                 .nestedScroll(scrollBehavior.nestedScrollConnection),
             images = images,
-            onImageClick = { index, image ->
+            onImageClick = { index, _ ->
                 bottomBarVisibleState.value = false
                 initialPage = index
                 shouldShowLargeImage.value = true
@@ -95,5 +96,11 @@ fun FavouritesPage(bottomBarVisibleState: MutableState<Boolean>) {
             }
         )
     }
-    AnimatedVisibilityLargeImageView(shouldShowLargeImage, initialPage, images, bottomBarVisibleState)
+    AnimatedVisibilityLargeImageView(
+        navController,
+        shouldShowLargeImage,
+        initialPage,
+        images,
+        bottomBarVisibleState
+    )
 }

--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -93,7 +93,8 @@ interface GelbooruBasedImageBoard : ImageBoard {
     }
 
     override fun loadImage(postId: String, postListKey: String?): Image? {
-        return loadPage("id:$postId", 0).getOrNull(0)
+        val parsedPostId = postId.toIntOrNull() ?: return null
+        return loadPage("id:$parsedPostId", 0).getOrNull(0)
     }
 
     override fun loadPage(tags: String, page: Int, postListKey: String?): List<Image> {
@@ -229,7 +230,8 @@ object Danbooru : ImageBoard {
     }
 
     override fun loadImage(postId: String, postListKey: String?): Image? {
-        return loadPage("id:$postId", 0).getOrNull(0)
+        val parsedPostId = postId.toIntOrNull() ?: return null
+        return loadPage("id:$parsedPostId", 0).getOrNull(0)
     }
 
     override fun loadPage(tags: String, page: Int, postListKey: String?): List<Image> {
@@ -306,7 +308,8 @@ object Yandere : ImageBoard {
     }
 
     override fun loadImage(postId: String, postListKey: String?): Image? {
-        return loadPage("id:$postId", 0).getOrNull(0)
+        val parsedPostId = postId.toIntOrNull() ?: return null
+        return loadPage("id:$parsedPostId", 0).getOrNull(0)
     }
 
     override fun loadPage(tags: String, page: Int, postListKey: String?): List<Image> {

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -11,9 +11,7 @@ import androidx.activity.compose.PredictiveBackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
@@ -38,7 +36,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -57,7 +54,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavController
 import coil3.compose.SubcomposeAsyncImage
 import coil3.request.ImageRequest
 import kotlinx.coroutines.launch
@@ -68,18 +64,15 @@ import me.saket.telephoto.zoomable.zoomable
 import moe.apex.rule34.R
 import moe.apex.rule34.image.Image
 import moe.apex.rule34.preferences.DataSaver
-import moe.apex.rule34.preferences.ImageSource
 import moe.apex.rule34.preferences.LocalPreferences
 import moe.apex.rule34.prefs
 import moe.apex.rule34.util.showToast
 import moe.apex.rule34.ui.theme.BreadboardTheme
-import moe.apex.rule34.ui.theme.Typography
 import moe.apex.rule34.util.FullscreenLoadingSpinner
 import moe.apex.rule34.util.MustSetLocation
 import moe.apex.rule34.util.NAV_BAR_HEIGHT
 import moe.apex.rule34.util.SaveDirectorySelection
 import moe.apex.rule34.util.downloadImage
-
 
 
 private fun isUsingWiFi(context: Context): Boolean {
@@ -94,7 +87,6 @@ private fun isUsingWiFi(context: Context): Boolean {
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun LargeImageView(
-    navController: NavController,
     shouldShowLargeImage: MutableState<Boolean>,
     initialPage: Int,
     allImages: List<Image>
@@ -144,10 +136,7 @@ fun LargeImageView(
             progress.collect { backEvent ->
                 offset = (backEvent.progress * 300).dp
             }
-            if (navController.currentBackStackEntry?.destination?.route?.startsWith("deepLink") == true)
-                navController.popBackStack()
-            else
-                shouldShowLargeImage.value = false
+            shouldShowLargeImage.value = false
         }
         catch(_: Exception) { }
     }
@@ -367,41 +356,6 @@ fun LargeImageView(
                 canChangePage = isZoomedOut
                 forciblyShowBottomBar = false
             }
-        }
-    }
-}
-
-
-@Composable
-fun DeepLinkLargeImageView(navController: NavController, domain: String?, postId: String?) {
-    if (domain == null || postId == null) return ImageNotFound()
-
-    val imageSource = ImageSource.getFromDomain(domain) ?: return ImageNotFound()
-
-    val image = remember { imageSource.site.loadImage(postId) }
-    if (image == null) return ImageNotFound()
-
-    LargeImageView(
-        navController,
-        mutableStateOf(true),
-        0,
-        listOf(image)
-    )
-}
-
-
-@Composable
-private fun ImageNotFound() {
-    BreadboardTheme {
-        Column(
-            verticalArrangement = Arrangement.Center,
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.fillMaxSize()
-        ) {
-            Text(
-                text = "Image not found :(",
-                style = Typography.titleLarge
-            )
         }
     }
 }

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -7,7 +7,6 @@ import android.content.res.Configuration
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.util.Log
-import androidx.activity.compose.BackHandler
 import androidx.activity.compose.PredictiveBackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -88,7 +88,7 @@ private fun isUsingWiFi(context: Context): Boolean {
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun LargeImageView(
-    shouldShowLargeImage: MutableState<Boolean>,
+    visible: MutableState<Boolean>,
     initialPage: Int,
     allImages: List<Image>
 ) {
@@ -107,7 +107,7 @@ fun LargeImageView(
     var isDownloading by remember { mutableStateOf(false) }
 
     if (allImages.isEmpty()) {
-        shouldShowLargeImage.value = false
+        visible.value = false
         return
     }
 
@@ -128,20 +128,19 @@ fun LargeImageView(
         InfoSheet(currentImage, popupVisibilityState)
     }
 
-    LaunchedEffect(shouldShowLargeImage.value) {
-        if (shouldShowLargeImage.value) offset = 0.dp
+    LaunchedEffect(visible.value) {
+        if (visible.value) offset = 0.dp
     }
 
-    if (context is MainActivity)
-        PredictiveBackHandler(shouldShowLargeImage.value) { progress ->
-            try {
-                progress.collect { backEvent ->
-                    offset = (backEvent.progress * 300).dp
-                }
-                shouldShowLargeImage.value = false
+    PredictiveBackHandler(visible.value && context is MainActivity) { progress ->
+        try {
+            progress.collect { backEvent ->
+                offset = (backEvent.progress * 300).dp
             }
-            catch (_: Exception) { }
+            visible.value = false
         }
+        catch (_: Exception) { }
+    }
 
     @Composable
     fun LargeImage(imageUrl: String, previewImageUrl: String, aspectRatio: Float?) {

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -7,6 +7,7 @@ import android.content.res.Configuration
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.util.Log
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.PredictiveBackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
@@ -61,6 +62,7 @@ import kotlinx.coroutines.runBlocking
 import me.saket.telephoto.zoomable.ZoomSpec
 import me.saket.telephoto.zoomable.rememberZoomableState
 import me.saket.telephoto.zoomable.zoomable
+import moe.apex.rule34.MainActivity
 import moe.apex.rule34.R
 import moe.apex.rule34.image.Image
 import moe.apex.rule34.preferences.DataSaver
@@ -131,15 +133,16 @@ fun LargeImageView(
         if (shouldShowLargeImage.value) offset = 0.dp
     }
 
-    PredictiveBackHandler(shouldShowLargeImage.value) { progress ->
-        try {
-            progress.collect { backEvent ->
-                offset = (backEvent.progress * 300).dp
+    if (context is MainActivity)
+        PredictiveBackHandler(shouldShowLargeImage.value) { progress ->
+            try {
+                progress.collect { backEvent ->
+                    offset = (backEvent.progress * 300).dp
+                }
+                shouldShowLargeImage.value = false
             }
-            shouldShowLargeImage.value = false
+            catch (_: Exception) { }
         }
-        catch(_: Exception) { }
-    }
 
     @Composable
     fun LargeImage(imageUrl: String, previewImageUrl: String, aspectRatio: Float?) {

--- a/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
@@ -374,5 +374,18 @@ enum class ImageSource(override val description: String, val site: ImageBoard) :
     DANBOORU("Danbooru", Danbooru),
     GELBOORU("Gelbooru", Gelbooru),
     YANDERE("Yande.re", Yandere),
-    R34("Rule34", Rule34)
+    R34("Rule34", Rule34);
+
+    companion object {
+        fun getFromDomain(domain: String): ImageSource? {
+            return when (domain) {
+                "safebooru.org" -> ImageSource.SAFEBOORU
+                "danbooru.donmai.us" -> ImageSource.DANBOORU
+                "gelbooru.com" -> ImageSource.GELBOORU
+                "yande.re" -> ImageSource.YANDERE
+                "rule34.xxx" -> ImageSource.R34
+                else -> null
+            }
+        }
+    }
 }

--- a/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
@@ -377,15 +377,25 @@ enum class ImageSource(override val description: String, val site: ImageBoard) :
     R34("Rule34", Rule34);
 
     companion object {
-        fun getFromDomain(domain: String): ImageSource? {
-            return when (domain) {
-                "safebooru.org" -> ImageSource.SAFEBOORU
-                "danbooru.donmai.us" -> ImageSource.DANBOORU
-                "gelbooru.com" -> ImageSource.GELBOORU
-                "yande.re" -> ImageSource.YANDERE
-                "rule34.xxx" -> ImageSource.R34
-                else -> null
+        fun loadImageFromUri(uri: Uri): Image? {
+            val imageSource = when (uri.host) {
+                "safebooru.org" -> SAFEBOORU
+                "danbooru.donmai.us" -> DANBOORU
+                "gelbooru.com" -> GELBOORU
+                "yande.re" -> YANDERE
+                "rule34.xxx" -> R34
+                else -> return null
             }
+
+            val postId = when (imageSource) {
+                SAFEBOORU,
+                GELBOORU,
+                R34 -> uri.getQueryParameter("id")
+                DANBOORU -> uri.path?.split('/')?.getOrNull(2)
+                YANDERE -> uri.path?.split('/')?.getOrNull(3)
+            } ?: return null
+
+            return imageSource.site.loadImage(postId)
         }
     }
 }

--- a/app/src/main/java/moe/apex/rule34/util/Ui.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Ui.kt
@@ -98,15 +98,15 @@ fun FullscreenLoadingSpinner() {
 
 @Composable
 fun AnimatedVisibilityLargeImageView(
+    navController: NavController,
     shouldShowLargeImage: MutableState<Boolean>,
     initialPage: Int,
     allImages: List<Image>,
     bottomBarVisibleState: MutableState<Boolean>? = null
 ) {
     LaunchedEffect(shouldShowLargeImage.value) {
-        if (bottomBarVisibleState != null) {
+        if (bottomBarVisibleState != null)
             bottomBarVisibleState.value = !shouldShowLargeImage.value
-        }
     }
 
     AnimatedVisibility(
@@ -115,8 +115,9 @@ fun AnimatedVisibilityLargeImageView(
         exit = slideOutVertically(targetOffsetY = { it })
     ) {
         LargeImageView(
-            initialPage,
+            navController,
             shouldShowLargeImage,
+            initialPage,
             allImages
         )
     }

--- a/app/src/main/java/moe/apex/rule34/util/Ui.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Ui.kt
@@ -98,7 +98,6 @@ fun FullscreenLoadingSpinner() {
 
 @Composable
 fun AnimatedVisibilityLargeImageView(
-    navController: NavController,
     shouldShowLargeImage: MutableState<Boolean>,
     initialPage: Int,
     allImages: List<Image>,
@@ -115,7 +114,6 @@ fun AnimatedVisibilityLargeImageView(
         exit = slideOutVertically(targetOffsetY = { it })
     ) {
         LargeImageView(
-            navController,
             shouldShowLargeImage,
             initialPage,
             allImages


### PR DESCRIPTION
Adds support for image board deep links with proper URI matching. Since `queryAdvancedPattern` has only been available since Android 15, we can only check for path prefixes for devices running Android 14 or lower.

The post IDs were typed as `String` in case we add an image board that does not use numerical IDs.

Also, this PR fixes #16.