### PR TITLE
Add deep link support for yande.re direct image links

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
                 <data android:host="safebooru.org" />
                 <data android:host="gelbooru.com" />
                 <data android:host="rule34.xxx" />
+
                 <data android:path="/index.php" />
                 <data android:queryAdvancedPattern="id=[0-9]+" />
             </intent-filter>
@@ -48,6 +49,7 @@
 
                 <data android:scheme="https" />
                 <data android:host="danbooru.donmai.us" />
+
                 <data android:pathPattern="/posts/.*" />
                 <data android:pathAdvancedPattern="/posts/[0-9]+" />
             </intent-filter>
@@ -58,8 +60,13 @@
 
                 <data android:scheme="https" />
                 <data android:host="yande.re" />
+                <data android:host="files.yande.re" />
+
                 <data android:pathPattern="/post/show/.*" />
                 <data android:pathAdvancedPattern="/post/show/[0-9]+" />
+
+                <data android:pathPattern="/image/.*/yande.re .*" />
+                <data android:pathAdvancedPattern="/image/[a-z0-9]+/yande.re [0-9]+ .*" />
             </intent-filter>
         </activity>
     </application>

--- a/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
@@ -382,7 +382,7 @@ enum class ImageSource(override val description: String, val site: ImageBoard) :
                 "safebooru.org" -> SAFEBOORU
                 "danbooru.donmai.us" -> DANBOORU
                 "gelbooru.com" -> GELBOORU
-                "yande.re" -> YANDERE
+                "yande.re", "files.yande.re" -> YANDERE
                 "rule34.xxx" -> R34
                 else -> return null
             }
@@ -392,7 +392,10 @@ enum class ImageSource(override val description: String, val site: ImageBoard) :
                 GELBOORU,
                 R34 -> uri.getQueryParameter("id")
                 DANBOORU -> uri.path?.split('/')?.getOrNull(2)
-                YANDERE -> uri.path?.split('/')?.getOrNull(3)
+                YANDERE -> {
+                    val postId = uri.path?.split('/')?.getOrNull(3)
+                    if (uri.host == "files.yande.re") postId?.split(" ")?.getOrNull(1) else postId
+                }
             } ?: return null
 
             return imageSource.site.loadImage(postId)


### PR DESCRIPTION
Adding this since Yande.re's direct links include the post ID (`https://files.yande.re/image/<hash>/yande.re <id> <tags>.<ext>`).