### PR TITLE
Parent and child posts support

### DIFF
--- a/app/src/main/java/moe/apex/rule34/DeepLinkActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/DeepLinkActivity.kt
@@ -20,8 +20,8 @@ import coil3.gif.AnimatedImageDecoder
 import coil3.gif.GifDecoder
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
-import moe.apex.rule34.navigation.DeepLinkImageView
 import moe.apex.rule34.navigation.Navigation
+import moe.apex.rule34.preferences.ImageSource
 import moe.apex.rule34.preferences.LocalPreferences
 import moe.apex.rule34.viewmodel.BreadboardViewModel
 
@@ -54,8 +54,8 @@ class DeepLinkActivity : SingletonImageLoader.Factory, ComponentActivity() {
             CompositionLocalProvider(LocalPreferences provides prefs) {
                 DisposableEffect(Unit) {
                     val listener = Consumer<Intent> { newIntent ->
-                        val uri = newIntent.data.toString()
-                        navController.navigate(DeepLinkImageView(uri))
+                        val destination = ImageSource.uriToImageView(newIntent.data)
+                        if (destination != null) navController.navigate(destination)
                     }
                     addOnNewIntentListener(listener)
                     onDispose { removeOnNewIntentListener(listener) }

--- a/app/src/main/java/moe/apex/rule34/DeepLinkActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/DeepLinkActivity.kt
@@ -20,8 +20,8 @@ import coil3.gif.AnimatedImageDecoder
 import coil3.gif.GifDecoder
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import moe.apex.rule34.navigation.ImageView
 import moe.apex.rule34.navigation.Navigation
-import moe.apex.rule34.preferences.ImageSource
 import moe.apex.rule34.preferences.LocalPreferences
 import moe.apex.rule34.viewmodel.BreadboardViewModel
 
@@ -54,8 +54,8 @@ class DeepLinkActivity : SingletonImageLoader.Factory, ComponentActivity() {
             CompositionLocalProvider(LocalPreferences provides prefs) {
                 DisposableEffect(Unit) {
                     val listener = Consumer<Intent> { newIntent ->
-                        val destination = ImageSource.uriToImageView(newIntent.data)
-                        if (destination != null) navController.navigate(destination)
+                        val uri = newIntent.data
+                        if (uri != null) ImageView.fromUri(uri)?.let { navController.navigate(it) }
                     }
                     addOnNewIntentListener(listener)
                     onDispose { removeOnNewIntentListener(listener) }

--- a/app/src/main/java/moe/apex/rule34/DeepLinkActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/DeepLinkActivity.kt
@@ -1,28 +1,18 @@
 package moe.apex.rule34
 
 import android.content.Intent
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import androidx.core.util.Consumer
 import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.compose.rememberNavController
 import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.SingletonImageLoader
@@ -30,11 +20,10 @@ import coil3.gif.AnimatedImageDecoder
 import coil3.gif.GifDecoder
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
-import moe.apex.rule34.largeimageview.LargeImageView
-import moe.apex.rule34.preferences.ImageSource
+import moe.apex.rule34.navigation.DeepLinkImageView
+import moe.apex.rule34.navigation.Navigation
 import moe.apex.rule34.preferences.LocalPreferences
-import moe.apex.rule34.ui.theme.BreadboardTheme
-import moe.apex.rule34.ui.theme.Typography
+import moe.apex.rule34.viewmodel.BreadboardViewModel
 
 
 class DeepLinkActivity : SingletonImageLoader.Factory, ComponentActivity() {
@@ -59,46 +48,20 @@ class DeepLinkActivity : SingletonImageLoader.Factory, ComponentActivity() {
         val initialPrefs = runBlocking { prefs.getPreferences.first() }
 
         setContent {
+            val navController = rememberNavController()
             val prefs = prefs.getPreferences.collectAsState(initialPrefs).value
-            var uri by rememberSaveable { mutableStateOf(intent.data) }
+            val viewModel = viewModel(BreadboardViewModel::class.java)
             CompositionLocalProvider(LocalPreferences provides prefs) {
                 DisposableEffect(Unit) {
-                    val listener = Consumer<Intent> { newIntent -> uri = newIntent.data }
+                    val listener = Consumer<Intent> { newIntent ->
+                        val uri = newIntent.data.toString()
+                        navController.navigate(DeepLinkImageView(uri))
+                    }
                     addOnNewIntentListener(listener)
                     onDispose { removeOnNewIntentListener(listener) }
                 }
-                BreadboardTheme {
-                    Surface {
-                        DeepLinkLargeImageView(uri)
-                    }
-                }
+                Navigation(navController, viewModel, intent.data)
             }
         }
-    }
-}
-
-
-@Composable
-fun DeepLinkLargeImageView(uri: Uri?) {
-    val image = uri?.let { ImageSource.loadImageFromUri(it) }
-    if (image == null) return ImageNotFound()
-
-    LargeImageView(
-        initialPage = 0,
-        allImages = listOf(image)
-    )
-}
-
-
-@Composable
-fun ImageNotFound() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(
-            text = "Image not found :(",
-            style = Typography.titleLarge
-        )
     }
 }

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -351,8 +351,8 @@ fun HomeScreen(navController: NavController, focusRequester: FocusRequester, vie
             val searchTags = currentSource.site.formatTagString(tagChipList)
             val ratingsFilter = if (prefs.filterRatingsLocally) ""
                                 else ImageRating.buildSearchStringFor(prefs.ratingsFilter)
-            val searchQuery = searchTags + if (ratingsFilter.isNotEmpty()) "+$ratingsFilter" else ""
-            navController.navigate(Results(searchQuery))
+            val query = searchTags + if (ratingsFilter.isNotEmpty()) "+$ratingsFilter" else ""
+            navController.navigate(Results(query, prefs.imageSource.name))
         }
     }
 

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -352,7 +352,7 @@ fun HomeScreen(navController: NavController, focusRequester: FocusRequester, vie
             val ratingsFilter = if (prefs.filterRatingsLocally) ""
                                 else ImageRating.buildSearchStringFor(prefs.ratingsFilter)
             val query = searchTags + if (ratingsFilter.isNotEmpty()) "+$ratingsFilter" else ""
-            navController.navigate(Results(query, prefs.imageSource.name))
+            navController.navigate(Results(prefs.imageSource.name, query))
         }
     }
 

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -366,7 +366,7 @@ fun HomeScreen(navController: NavController, focusRequester: FocusRequester, vie
                             else ImageRating.buildSearchStringFor(prefs.ratingsFilter)
 
         val tags = searchTags + if (ratingsFilter.isNotEmpty()) "+$ratingsFilter" else ""
-        navController.navigate(Results(prefs.imageSource.name, tags))
+        navController.navigate(Results(prefs.imageSource, tags))
     }
 
     fun addAiExcludedTag(source: ImageSource) {

--- a/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import moe.apex.rule34.image.Image
+import moe.apex.rule34.preferences.ImageSource
 import moe.apex.rule34.preferences.LocalPreferences
 import moe.apex.rule34.prefs
 import moe.apex.rule34.util.AnimatedVisibilityLargeImageView
@@ -38,7 +39,7 @@ import moe.apex.rule34.util.withoutVertical
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SearchResults(navController: NavController, searchQuery: String) {
+fun SearchResults(navController: NavController, source: String, query: String) {
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(topAppBarState)
     val shouldShowLargeImage = remember { mutableStateOf(false) }
@@ -49,7 +50,7 @@ fun SearchResults(navController: NavController, searchQuery: String) {
 
     val prefs = LocalPreferences.current
     val preferencesRepository = LocalContext.current.prefs
-    val imageSource = prefs.imageSource.site
+    val imageSource = ImageSource.get(source)?.site ?: prefs.imageSource.site
     val filterLocally = prefs.filterRatingsLocally
     var pageNumber by remember { mutableIntStateOf(imageSource.firstPageIndex) }
 
@@ -101,7 +102,7 @@ fun SearchResults(navController: NavController, searchQuery: String) {
             initialLoad = {
                 withContext(Dispatchers.IO) {
                     try {
-                        val newImages = imageSource.loadPage(searchQuery, pageNumber)
+                        val newImages = imageSource.loadPage(query, pageNumber)
                         if (!allImages.addAll(newImages)) shouldKeepSearching = false
                         pageNumber++
                     } catch (e: Exception) {
@@ -114,7 +115,7 @@ fun SearchResults(navController: NavController, searchQuery: String) {
             if (shouldKeepSearching) {
                 scope.launch(Dispatchers.IO) {
                     try {
-                        val newImages = imageSource.loadPage(searchQuery, pageNumber)
+                        val newImages = imageSource.loadPage(query, pageNumber)
                         if (newImages.isNotEmpty()) {
                             pageNumber++
                             allImages.addAll(newImages.filter { it !in allImages })
@@ -130,5 +131,5 @@ fun SearchResults(navController: NavController, searchQuery: String) {
         }
     }
 
-    AnimatedVisibilityLargeImageView(shouldShowLargeImage, initialPage, imagesToDisplay)
+    AnimatedVisibilityLargeImageView(navController, shouldShowLargeImage, initialPage, imagesToDisplay)
 }

--- a/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
@@ -39,7 +39,7 @@ import moe.apex.rule34.util.withoutVertical
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SearchResults(navController: NavController, source: String, tags: String) {
+fun SearchResults(navController: NavController, source: ImageSource, tags: String) {
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(topAppBarState)
     val shouldShowLargeImage = remember { mutableStateOf(false) }
@@ -50,7 +50,7 @@ fun SearchResults(navController: NavController, source: String, tags: String) {
 
     val prefs = LocalPreferences.current
     val preferencesRepository = LocalContext.current.prefs
-    val imageSource = ImageSource.get(source)?.site ?: prefs.imageSource.site
+    val imageSource = source.site
     val filterLocally = prefs.filterRatingsLocally
     var pageNumber by remember { mutableIntStateOf(imageSource.firstPageIndex) }
 

--- a/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
@@ -39,7 +39,7 @@ import moe.apex.rule34.util.withoutVertical
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SearchResults(navController: NavController, source: String, query: String) {
+fun SearchResults(navController: NavController, source: String, tags: String) {
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(topAppBarState)
     val shouldShowLargeImage = remember { mutableStateOf(false) }
@@ -102,7 +102,7 @@ fun SearchResults(navController: NavController, source: String, query: String) {
             initialLoad = {
                 withContext(Dispatchers.IO) {
                     try {
-                        val newImages = imageSource.loadPage(query, pageNumber)
+                        val newImages = imageSource.loadPage(tags, pageNumber)
                         if (!allImages.addAll(newImages)) shouldKeepSearching = false
                         pageNumber++
                     } catch (e: Exception) {
@@ -115,7 +115,7 @@ fun SearchResults(navController: NavController, source: String, query: String) {
             if (shouldKeepSearching) {
                 scope.launch(Dispatchers.IO) {
                     try {
-                        val newImages = imageSource.loadPage(query, pageNumber)
+                        val newImages = imageSource.loadPage(tags, pageNumber)
                         if (newImages.isNotEmpty()) {
                             pageNumber++
                             allImages.addAll(newImages.filter { it !in allImages })

--- a/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
+++ b/app/src/main/java/moe/apex/rule34/favourites/Favourites.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import kotlinx.coroutines.launch
 import moe.apex.rule34.detailview.ImageGrid
 import moe.apex.rule34.image.ImageRating
@@ -32,7 +33,7 @@ import moe.apex.rule34.util.MainScreenScaffold
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun FavouritesPage(bottomBarVisibleState: MutableState<Boolean>) {
+fun FavouritesPage(navController: NavController, bottomBarVisibleState: MutableState<Boolean>) {
     val prefs = LocalPreferences.current
     val preferencesRepository = LocalContext.current.prefs
     val topAppBarState = rememberTopAppBarState()
@@ -94,5 +95,6 @@ fun FavouritesPage(bottomBarVisibleState: MutableState<Boolean>) {
             }
         )
     }
-    AnimatedVisibilityLargeImageView(shouldShowLargeImage, initialPage, images, bottomBarVisibleState)
+
+    AnimatedVisibilityLargeImageView(navController, shouldShowLargeImage, initialPage, images, bottomBarVisibleState)
 }

--- a/app/src/main/java/moe/apex/rule34/image/Image.kt
+++ b/app/src/main/java/moe/apex/rule34/image/Image.kt
@@ -10,6 +10,8 @@ import moe.apex.rule34.tag.TagGroup
 
 @Serializable
 data class ImageMetadata(
+    val parentId: String? = null,
+    val hasChildren: Boolean? = null,
     val artist: String? = null,
     val source: String? = null,
     @Deprecated(
@@ -30,6 +32,7 @@ data class ImageMetadata(
 
 @Serializable
 data class Image(
+    val id: String? = null,
     val fileName: String,
     val fileFormat: String,
     val previewUrl: String,

--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -22,8 +22,8 @@ interface ImageBoard {
     fun loadAutoComplete(searchString: String): List<TagSuggestion> {
         val suggestions = mutableListOf<TagSuggestion>()
         val isExcluded = searchString.startsWith("-")
-        val query = searchString.replace("^-".toRegex(), "")
-        val body = RequestUtil.get(autoCompleteSearchUrl.format(query)) {
+        val tags = searchString.replace("^-".toRegex(), "")
+        val body = RequestUtil.get(autoCompleteSearchUrl.format(tags)) {
             addHeader("Referrer", baseUrl)
         }.get()
         val results = JSONArray(body)
@@ -51,7 +51,7 @@ interface ImageBoard {
 
     fun parseImage(e: JSONObject): Image?
 
-    fun loadImage(postId: String): Image?
+    fun loadImage(id: String): Image?
 
     fun loadPage(tags: String, page: Int): List<Image>
 
@@ -96,9 +96,9 @@ interface GelbooruBasedImageBoard : ImageBoard {
         return Image(id, fileName, fileFormat, previewUrl, fileUrl, sampleUrl, imageSource, aspectRatio, metadata)
     }
 
-    fun loadImage(postId: String, postListKey: String?, imageSource: ImageSource): Image? {
-        val parsedPostId = postId.toIntOrNull() ?: return null
-        return loadPage("id:$parsedPostId", 0, postListKey, imageSource).getOrNull(0)
+    fun loadImage(id: String, postListKey: String?, imageSource: ImageSource): Image? {
+        val parsedId = id.toIntOrNull() ?: return null
+        return loadPage("id:$parsedId", 0, postListKey, imageSource).getOrNull(0)
     }
 
     fun loadPage(tags: String, page: Int, postListKey: String?, imageSource: ImageSource): List<Image> {
@@ -152,8 +152,8 @@ object Rule34 : GelbooruBasedImageBoard {
         return parseImage(e, ImageSource.R34)
     }
 
-    override fun loadImage(postId: String): Image? {
-        return loadImage(postId, null, ImageSource.R34)
+    override fun loadImage(id: String): Image? {
+        return loadImage(id, null, ImageSource.R34)
     }
 
     override fun loadPage(tags: String, page: Int): List<Image> {
@@ -173,8 +173,8 @@ object Safebooru : GelbooruBasedImageBoard {
         return parseImage(e, ImageSource.SAFEBOORU)
     }
 
-    override fun loadImage(postId: String): Image? {
-        return loadImage(postId, null, ImageSource.SAFEBOORU)
+    override fun loadImage(id: String): Image? {
+        return loadImage(id, null, ImageSource.SAFEBOORU)
     }
 
     override fun loadPage(tags: String, page: Int): List<Image> {
@@ -194,8 +194,8 @@ object Gelbooru : GelbooruBasedImageBoard {
         return parseImage(e, ImageSource.GELBOORU)
     }
 
-    override fun loadImage(postId: String): Image? {
-        return loadImage(postId, "post", ImageSource.GELBOORU)
+    override fun loadImage(id: String): Image? {
+        return loadImage(id, "post", ImageSource.GELBOORU)
     }
 
     override fun loadPage(tags: String, page: Int): List<Image> {
@@ -266,9 +266,9 @@ object Danbooru : ImageBoard {
         return Image(id, fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.DANBOORU, aspectRatio, metadata)
     }
 
-    override fun loadImage(postId: String): Image? {
-        val parsedPostId = postId.toIntOrNull() ?: return null
-        return loadPage("id:$parsedPostId", 0).getOrNull(0)
+    override fun loadImage(id: String): Image? {
+        val parsedId = id.toIntOrNull() ?: return null
+        return loadPage("id:$parsedId", 0).getOrNull(0)
     }
 
     override fun loadPage(tags: String, page: Int): List<Image> {
@@ -349,9 +349,9 @@ object Yandere : ImageBoard {
         return Image(id, fileName, fileFormat, previewUrl, fileUrl, sampleUrl, ImageSource.YANDERE, aspectRatio, metadata)
     }
 
-    override fun loadImage(postId: String): Image? {
-        val parsedPostId = postId.toIntOrNull() ?: return null
-        return loadPage("id:$parsedPostId", 0).getOrNull(0)
+    override fun loadImage(id: String): Image? {
+        val parsedId = id.toIntOrNull() ?: return null
+        return loadPage("id:$parsedId", 0).getOrNull(0)
     }
 
     override fun loadPage(tags: String, page: Int): List<Image> {

--- a/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
@@ -125,7 +125,7 @@ fun InfoSheet(navController: NavController, image: Image, visibilityState: Mutab
                             navController.navigate(Results(image.imageSource.name, "parent:$it"))
                         }
                     ) {
-                        Text("View child images")
+                        Text("View related images")
                     }
                 }
             }

--- a/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
@@ -108,7 +108,7 @@ fun InfoSheet(navController: NavController, image: Image, visibilityState: Mutab
                         .align(Alignment.CenterHorizontally),
                     onClick = {
                         visibilityState.value = false
-                        navController.navigate(ImageView(image.imageSource.name, it))
+                        navController.navigate(ImageView(image.imageSource, it))
                     }
                 ) {
                     Text("View parent image")
@@ -122,7 +122,7 @@ fun InfoSheet(navController: NavController, image: Image, visibilityState: Mutab
                             .align(Alignment.CenterHorizontally),
                         onClick = {
                             visibilityState.value = false
-                            navController.navigate(Results(image.imageSource.name, "parent:$it"))
+                            navController.navigate(Results(image.imageSource, "parent:$it"))
                         }
                     ) {
                         Text("View related images")
@@ -158,7 +158,7 @@ fun InfoSheet(navController: NavController, image: Image, visibilityState: Mutab
                     CombinedClickableSuggestionChip(
                         onClick = {
                             visibilityState.value = false
-                            navController.navigate(Results(image.imageSource.name, tag))
+                            navController.navigate(Results(image.imageSource, tag))
                         },
                         onLongClick = { copyText(context, clip, tag) },
                         label = { Text(tag) }

--- a/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
-import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -47,9 +46,13 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import kotlinx.coroutines.launch
 import moe.apex.rule34.image.Image
+import moe.apex.rule34.navigation.ImageView
+import moe.apex.rule34.navigation.Results
 import moe.apex.rule34.util.CHIP_SPACING
+import moe.apex.rule34.util.CombinedClickableSuggestionChip
 import moe.apex.rule34.util.Heading
 import moe.apex.rule34.util.LargeVerticalSpacer
 import moe.apex.rule34.util.copyText
@@ -58,7 +61,7 @@ import moe.apex.rule34.util.pluralise
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
-fun InfoSheet(image: Image, visibilityState: MutableState<Boolean>) {
+fun InfoSheet(navController: NavController, image: Image, visibilityState: MutableState<Boolean>) {
     if (image.metadata == null) return
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -98,6 +101,34 @@ fun InfoSheet(image: Image, visibilityState: MutableState<Boolean>) {
         contentWindowInsets = { BottomSheetDefaults.windowInsets.only(WindowInsetsSides.Horizontal) }
     ) {
         Column(Modifier.verticalScroll(rememberScrollState())) {
+            image.metadata.parentId?.let {
+                TextButton(
+                    modifier = Modifier
+                        .padding(top = 4.dp)
+                        .align(Alignment.CenterHorizontally),
+                    onClick = {
+                        visibilityState.value = false
+                        navController.navigate(ImageView(it, image.imageSource.name))
+                    }
+                ) {
+                    Text("View parent image")
+                }
+            }
+            if (image.metadata.hasChildren == true) {
+                image.id?.let {
+                    TextButton(
+                        modifier = Modifier
+                            .padding(top = 4.dp)
+                            .align(Alignment.CenterHorizontally),
+                        onClick = {
+                            visibilityState.value = false
+                            navController.navigate(Results("parent:$it", image.imageSource.name))
+                        }
+                    ) {
+                        Text("View child images")
+                    }
+                }
+            }
             image.metadata.artist?.let {
                 Heading(text = "Artist")
                 PaddedText(it)
@@ -124,8 +155,12 @@ fun InfoSheet(image: Image, visibilityState: MutableState<Boolean>) {
                     horizontalArrangement = Arrangement.spacedBy(CHIP_SPACING.dp, Alignment.Start)
                 ) { index ->
                     val tag = it.tags[index]
-                    SuggestionChip(
-                        onClick = { copyText(context, clip, tag) },
+                    CombinedClickableSuggestionChip(
+                        onClick = {
+                            visibilityState.value = false
+                            navController.navigate(Results(tag, image.imageSource.name))
+                        },
+                        onLongClick = { copyText(context, clip, tag) },
                         label = { Text(tag) }
                     )
                 }

--- a/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
@@ -108,7 +108,7 @@ fun InfoSheet(navController: NavController, image: Image, visibilityState: Mutab
                         .align(Alignment.CenterHorizontally),
                     onClick = {
                         visibilityState.value = false
-                        navController.navigate(ImageView(it, image.imageSource.name))
+                        navController.navigate(ImageView(image.imageSource.name, it))
                     }
                 ) {
                     Text("View parent image")
@@ -122,7 +122,7 @@ fun InfoSheet(navController: NavController, image: Image, visibilityState: Mutab
                             .align(Alignment.CenterHorizontally),
                         onClick = {
                             visibilityState.value = false
-                            navController.navigate(Results("parent:$it", image.imageSource.name))
+                            navController.navigate(Results(image.imageSource.name, "parent:$it"))
                         }
                     ) {
                         Text("View child images")
@@ -158,7 +158,7 @@ fun InfoSheet(navController: NavController, image: Image, visibilityState: Mutab
                     CombinedClickableSuggestionChip(
                         onClick = {
                             visibilityState.value = false
-                            navController.navigate(Results(tag, image.imageSource.name))
+                            navController.navigate(Results(image.imageSource.name, tag))
                         },
                         onLongClick = { copyText(context, clip, tag) },
                         label = { Text(tag) }

--- a/app/src/main/java/moe/apex/rule34/navigation/Destinations.kt
+++ b/app/src/main/java/moe/apex/rule34/navigation/Destinations.kt
@@ -7,11 +7,23 @@ import kotlin.reflect.KClass
 
 
 @Serializable
+data class ImageView(
+    val source: String,
+    val id: String
+)
+
+@Serializable
+data class DeepLinkImageView(
+    val uri: String
+)
+
+@Serializable
 object Search
 
 @Serializable
 data class Results(
-    val searchQuery: String,
+    val source: String,
+    val query: String
 )
 
 @Serializable

--- a/app/src/main/java/moe/apex/rule34/navigation/Destinations.kt
+++ b/app/src/main/java/moe/apex/rule34/navigation/Destinations.kt
@@ -23,7 +23,7 @@ object Search
 @Serializable
 data class Results(
     val source: String,
-    val query: String
+    val tags: String
 )
 
 @Serializable

--- a/app/src/main/java/moe/apex/rule34/navigation/Destinations.kt
+++ b/app/src/main/java/moe/apex/rule34/navigation/Destinations.kt
@@ -1,9 +1,15 @@
 package moe.apex.rule34.navigation
 
+import android.net.Uri
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
 import kotlinx.serialization.Serializable
 import moe.apex.rule34.preferences.ImageSource
+import moe.apex.rule34.preferences.ImageSource.DANBOORU
+import moe.apex.rule34.preferences.ImageSource.GELBOORU
+import moe.apex.rule34.preferences.ImageSource.R34
+import moe.apex.rule34.preferences.ImageSource.SAFEBOORU
+import moe.apex.rule34.preferences.ImageSource.YANDERE
 import kotlin.reflect.KClass
 
 
@@ -11,7 +17,33 @@ import kotlin.reflect.KClass
 data class ImageView(
     val source: ImageSource,
     val id: String
-)
+) {
+    companion object {
+        fun fromUri(uri: Uri): ImageView? {
+            val imageSource = when (uri.host) {
+                "safebooru.org" -> SAFEBOORU
+                "danbooru.donmai.us" -> DANBOORU
+                "gelbooru.com" -> GELBOORU
+                "yande.re", "files.yande.re" -> YANDERE
+                "rule34.xxx" -> R34
+                else -> return null
+            }
+
+            val postId = when (imageSource) {
+                SAFEBOORU,
+                GELBOORU,
+                R34 -> uri.getQueryParameter("id")
+                DANBOORU -> uri.path?.split('/')?.getOrNull(2)
+                YANDERE -> {
+                    val postId = uri.path?.split('/')?.getOrNull(3)
+                    if (uri.host == "files.yande.re") postId?.split(" ")?.getOrNull(1) else postId
+                }
+            } ?: return null
+
+            return ImageView(imageSource, postId)
+        }
+    }
+}
 
 @Serializable
 object Search

--- a/app/src/main/java/moe/apex/rule34/navigation/Destinations.kt
+++ b/app/src/main/java/moe/apex/rule34/navigation/Destinations.kt
@@ -3,18 +3,14 @@ package moe.apex.rule34.navigation
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
 import kotlinx.serialization.Serializable
+import moe.apex.rule34.preferences.ImageSource
 import kotlin.reflect.KClass
 
 
 @Serializable
 data class ImageView(
-    val source: String,
+    val source: ImageSource,
     val id: String
-)
-
-@Serializable
-data class DeepLinkImageView(
-    val uri: String
 )
 
 @Serializable
@@ -22,7 +18,7 @@ object Search
 
 @Serializable
 data class Results(
-    val source: String,
+    val source: ImageSource,
     val tags: String
 )
 

--- a/app/src/main/java/moe/apex/rule34/navigation/Navigation.kt
+++ b/app/src/main/java/moe/apex/rule34/navigation/Navigation.kt
@@ -134,8 +134,7 @@ fun Navigation(navController: NavHostController, viewModel: BreadboardViewModel,
                 NavHost(
                     modifier = Modifier.padding(paddingValues.withoutVertical()),
                     navController = navController,
-                    startDestination = if (uri == null) Search
-                                       else DeepLinkImageView(uri.toString()),
+                    startDestination = ImageSource.uriToImageView(uri) ?: Search,
                     enterTransition = {
                         if (targetState.destination.routeIs(Results::class))
                             materialSharedAxisXIn(!isRtl, slideDistance)
@@ -159,11 +158,7 @@ fun Navigation(navController: NavHostController, viewModel: BreadboardViewModel,
                 ) {
                     composable<ImageView> {
                         val args = it.toRoute<ImageView>()
-                        LazyLargeImageView(navController) { ImageSource.get(args.source)?.site?.loadImage(args.id) }
-                    }
-                    composable<DeepLinkImageView> {
-                        val args = it.toRoute<DeepLinkImageView>()
-                        LazyLargeImageView(navController) { ImageSource.loadImageFromUri(args.uri.toUri()) }
+                        LazyLargeImageView(navController) { args.source.site.loadImage(args.id) }
                     }
                     composable<Search> { HomeScreen(navController, focusRequester, viewModel) }
                     composable<Results> {

--- a/app/src/main/java/moe/apex/rule34/navigation/Navigation.kt
+++ b/app/src/main/java/moe/apex/rule34/navigation/Navigation.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.LayoutDirection
-import androidx.core.net.toUri
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -36,7 +35,6 @@ import moe.apex.rule34.R
 import moe.apex.rule34.detailview.SearchResults
 import moe.apex.rule34.favourites.FavouritesPage
 import moe.apex.rule34.largeimageview.LazyLargeImageView
-import moe.apex.rule34.preferences.ImageSource
 import moe.apex.rule34.preferences.PreferencesScreen
 import moe.apex.rule34.ui.theme.BreadboardTheme
 import moe.apex.rule34.util.withoutVertical
@@ -134,7 +132,7 @@ fun Navigation(navController: NavHostController, viewModel: BreadboardViewModel,
                 NavHost(
                     modifier = Modifier.padding(paddingValues.withoutVertical()),
                     navController = navController,
-                    startDestination = ImageSource.uriToImageView(uri) ?: Search,
+                    startDestination = uri?.let { ImageView.fromUri(it) } ?: Search,
                     enterTransition = {
                         if (targetState.destination.routeIs(Results::class))
                             materialSharedAxisXIn(!isRtl, slideDistance)

--- a/app/src/main/java/moe/apex/rule34/navigation/Navigation.kt
+++ b/app/src/main/java/moe/apex/rule34/navigation/Navigation.kt
@@ -130,9 +130,9 @@ fun Navigation(navController: NavHostController, viewModel: BreadboardViewModel,
                         }
                     }
                 }
-            ) {
+            ) { paddingValues ->
                 NavHost(
-                    modifier = Modifier.padding(it.withoutVertical()),
+                    modifier = Modifier.padding(paddingValues.withoutVertical()),
                     navController = navController,
                     startDestination = if (uri == null) Search
                                        else DeepLinkImageView(uri.toString()),
@@ -168,7 +168,7 @@ fun Navigation(navController: NavHostController, viewModel: BreadboardViewModel,
                     composable<Search> { HomeScreen(navController, focusRequester, viewModel) }
                     composable<Results> {
                         val args = it.toRoute<Results>()
-                        SearchResults(navController, args.source, args.query)
+                        SearchResults(navController, args.source, args.tags)
                     }
                     composable<Favourites> { FavouritesPage(navController, bottomBarVisibleState) }
                     composable<Settings> { PreferencesScreen(viewModel) }

--- a/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
@@ -452,6 +452,10 @@ enum class ImageSource(override val description: String, val site: ImageBoard) :
     R34("Rule34", Rule34);
 
     companion object {
+        fun get(name: String): ImageSource? {
+            return ImageSource.entries.find { it.name == name }
+        }
+
         fun loadImageFromUri(uri: Uri): Image? {
             val imageSource = when (uri.host) {
                 "safebooru.org" -> SAFEBOORU

--- a/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
@@ -33,7 +33,6 @@ import moe.apex.rule34.image.ImageRating
 import moe.apex.rule34.image.Rule34
 import moe.apex.rule34.image.Safebooru
 import moe.apex.rule34.image.Yandere
-import moe.apex.rule34.navigation.ImageView
 import moe.apex.rule34.tag.TagCategory
 import moe.apex.rule34.util.availableRatingsForSource
 import moe.apex.rule34.util.extractPixivId
@@ -450,33 +449,5 @@ enum class ImageSource(override val description: String, val site: ImageBoard) :
     DANBOORU("Danbooru", Danbooru),
     GELBOORU("Gelbooru", Gelbooru),
     YANDERE("Yande.re", Yandere),
-    R34("Rule34", Rule34);
-
-    companion object {
-        fun uriToImageView(uri: Uri?): ImageView? {
-            if (uri == null) return null
-
-            val imageSource = when (uri.host) {
-                "safebooru.org" -> SAFEBOORU
-                "danbooru.donmai.us" -> DANBOORU
-                "gelbooru.com" -> GELBOORU
-                "yande.re", "files.yande.re" -> YANDERE
-                "rule34.xxx" -> R34
-                else -> return null
-            }
-
-            val postId = when (imageSource) {
-                SAFEBOORU,
-                GELBOORU,
-                R34 -> uri.getQueryParameter("id")
-                DANBOORU -> uri.path?.split('/')?.getOrNull(2)
-                YANDERE -> {
-                    val postId = uri.path?.split('/')?.getOrNull(3)
-                    if (uri.host == "files.yande.re") postId?.split(" ")?.getOrNull(1) else postId
-                }
-            } ?: return null
-
-            return ImageView(imageSource, postId)
-        }
-    }
+    R34("Rule34", Rule34)
 }

--- a/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Pref.kt
@@ -33,6 +33,7 @@ import moe.apex.rule34.image.ImageRating
 import moe.apex.rule34.image.Rule34
 import moe.apex.rule34.image.Safebooru
 import moe.apex.rule34.image.Yandere
+import moe.apex.rule34.navigation.ImageView
 import moe.apex.rule34.tag.TagCategory
 import moe.apex.rule34.util.availableRatingsForSource
 import moe.apex.rule34.util.extractPixivId
@@ -452,11 +453,9 @@ enum class ImageSource(override val description: String, val site: ImageBoard) :
     R34("Rule34", Rule34);
 
     companion object {
-        fun get(name: String): ImageSource? {
-            return ImageSource.entries.find { it.name == name }
-        }
+        fun uriToImageView(uri: Uri?): ImageView? {
+            if (uri == null) return null
 
-        fun loadImageFromUri(uri: Uri): Image? {
             val imageSource = when (uri.host) {
                 "safebooru.org" -> SAFEBOORU
                 "danbooru.donmai.us" -> DANBOORU
@@ -477,7 +476,7 @@ enum class ImageSource(override val description: String, val site: ImageBoard) :
                 }
             } ?: return null
 
-            return imageSource.site.loadImage(postId)
+            return ImageView(imageSource, postId)
         }
     }
 }

--- a/app/src/main/java/moe/apex/rule34/util/Ui.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Ui.kt
@@ -6,8 +6,10 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -43,6 +45,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SuggestionChip
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarScrollBehavior
@@ -122,6 +125,7 @@ fun FullscreenLoadingSpinner() {
 
 @Composable
 fun AnimatedVisibilityLargeImageView(
+    navController: NavController,
     shouldShowLargeImage: MutableState<Boolean>,
     initialPage: Int,
     allImages: List<Image>,
@@ -139,6 +143,7 @@ fun AnimatedVisibilityLargeImageView(
     ) {
         key(initialPage) {
             LargeImageView(
+                navController,
                 shouldShowLargeImage,
                 initialPage,
                 allImages
@@ -302,6 +307,31 @@ fun copyText(
     // if (SDK_INT < VERSION_CODES.TIRAMISU) { // Android 13 has its own text copied popup
     showToast(context, message)
     // }
+}
+
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun CombinedClickableSuggestionChip(
+    onClick: () -> Unit,
+    onLongClick: () -> Unit,
+    label: @Composable () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Box {
+        SuggestionChip(onClick = { }, label = label, interactionSource = interactionSource)
+        Box(
+            modifier = Modifier
+                .matchParentSize()
+                .combinedClickable(
+                    onClick = onClick,
+                    onLongClick = onLongClick,
+                    interactionSource = interactionSource,
+                    indication = null
+                )
+        )
+    }
 }
 
 


### PR DESCRIPTION
Adds a button to view parent or child posts on top of the info sheet. This PR also makes it so that clicking an image tag inside the info sheet searches for images with that tag.