### PR TITLE
2.7.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "moe.apex.rule34"
         minSdk 26
         targetSdk 35
-        versionCode 270
-        versionName "2.7.0"
+        versionCode 271
+        versionName "2.7.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
@@ -4,7 +4,6 @@ package moe.apex.rule34.largeimageview
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.webkit.URLUtil.isValidUrl
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ContextualFlowRow
@@ -63,6 +62,7 @@ import moe.apex.rule34.util.Heading
 import moe.apex.rule34.util.LargeVerticalSpacer
 import moe.apex.rule34.util.TitledModalBottomSheet
 import moe.apex.rule34.util.copyText
+import moe.apex.rule34.util.isWebLink
 import moe.apex.rule34.util.pluralise
 
 
@@ -179,7 +179,7 @@ fun InfoSheet(navController: NavController, image: Image, visibilityState: Mutab
             }
             image.metadata.source?.let {
                 Heading(text = "Source")
-                if (isValidUrl(it)) PaddedUrlText(it) else PaddedText(it)
+                if (it.isWebLink()) PaddedUrlText(it) else PaddedText(it)
                 LargeVerticalSpacer()
             }
             Heading(text = "Rating")

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -92,6 +92,7 @@ import moe.apex.rule34.util.NAV_BAR_HEIGHT
 import moe.apex.rule34.util.StorageLocationSelection
 import moe.apex.rule34.util.downloadImage
 import moe.apex.rule34.util.fixLink
+import moe.apex.rule34.util.isWebLink
 import moe.apex.rule34.util.saveUriToPref
 import moe.apex.rule34.viewmodel.BreadboardViewModel
 import java.net.SocketTimeoutException
@@ -268,7 +269,7 @@ fun LargeImageView(
                         CombinedClickableIconButton(
                             onClick = {
                                 var shareLink = currentImage.metadata?.pixivUrl
-                                    ?: currentImage.metadata?.source
+                                    ?: currentImage.metadata?.source.let { if (it?.isWebLink() == true) it else null }
                                     ?: currentImage.highestQualityFormatUrl
                                 if (prefs.useFixedLinks) shareLink = fixLink(shareLink)
                                 shareIntent.putExtra(Intent.EXTRA_TEXT, shareLink)

--- a/app/src/main/java/moe/apex/rule34/util/Links.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Links.kt
@@ -17,3 +17,8 @@ fun fixLink(link: String): String {
     }
     return link
 }
+
+
+fun String.isWebLink(): Boolean {
+    return this.startsWith("http://") || this.startsWith("https://")
+}


### PR DESCRIPTION
Makes non-web sources (like file:// URIs and other strings that aren't web URLs) non-clickable in the info sheet, and prevent the Share button from sharing these useless sources. Fixes #22