### PR TITLE
3.0.5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "moe.apex.breadboard"
         minSdk 26
         targetSdk 36
-        versionCode 304
-        versionName "3.0.4"
+        versionCode 305
+        versionName "3.0.5"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/moe/apex/rule34/DeepLinkActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/DeepLinkActivity.kt
@@ -1,8 +1,11 @@
 package moe.apex.rule34
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
+import android.provider.Browser
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -90,18 +93,29 @@ class DeepLinkActivity : SingletonImageLoader.Factory, ComponentActivity() {
     private fun openInBrowser(intent: Intent) {
         val uri = intent.data!!
 
-        // Chrome and Firefox seem to set this. We should use it if available.
-        val possibleBrowserPackage = intent.getStringExtra("com.android.browser.application_id")
+        // Not all apps set this but some like Chrome and Firefox do. We should use it if available.
+        val possibleBrowserPackage = intent.getStringExtra(Browser.EXTRA_APPLICATION_ID)
 
         if (possibleBrowserPackage != null) {
-            launchUriWithPackage(this, uri, possibleBrowserPackage)
-            return
+            try {
+                return launchUriWithPackage(this, uri, possibleBrowserPackage)
+            } catch (_: ActivityNotFoundException) {
+                /* Android System Intelligence (com.google.android.as) powers the "Open" action
+                   for supported apps when long-pressing an Imageboard URL and sets the browser
+                   intent extra to its own package name, but it can't handle the links itself. */
+                Log.i("openInBrowser", "Original browser package $possibleBrowserPackage is not capable of launching URI $uri")
+            }
         }
 
         /* Chrome sets the referrer to the address. Firefox uses its package name with this scheme.
            If the referrer scheme is an android-app and the app can handle the URL,
            we should use it to do so. */
         referrer?.takeIf { it.scheme == "android-app" }?.host?.let { attemptingPackage ->
+            // If the referrer is Breadboard itself but we already know Breadboard can't handle the link in-app, we shouldn't try to do so.
+            if (attemptingPackage == BuildConfig.APPLICATION_ID) {
+                Log.w("openInBrowser", "Intent came from Breadboard itself but Breadboard can't handle URI $uri. If the intention was to open in the browser, call launchInDefaultBrowser() instead.")
+                return@let
+            }
             val relaunchIntent = createViewIntent(uri, attemptingPackage)
             if (getDefaultPackageForIntent(packageManager, relaunchIntent) != null) {
                 startActivity(relaunchIntent)

--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -183,6 +183,8 @@ object Rule34 : GelbooruBasedImageBoard {
     override val autoCompleteCategoryMapping = emptyMap<String, String>()
     override val imageSearchUrl = "${baseUrl}index.php?page=dapi&json=1&s=post&q=index&limit=100&tags=%s&pid=%d"
     override val aiTagName = "ai_generated"
+    override val apiKeyCreationUrl = "https://rule34.xxx/index.php?page=account&s=options"
+    override val canLoadUnauthenticated = false
 
     override fun parseImage(e: JSONObject): Image? {
         return parseImage(e, ImageSource.R34)

--- a/app/src/main/java/moe/apex/rule34/preferences/BlockedTagsScreen.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/BlockedTagsScreen.kt
@@ -74,6 +74,7 @@ fun BlockedTagsScreen(navController: NavHostController) {
                     PreferenceTextBox(
                         value = content,
                         label = "Tags",
+                        autoCorrectEnabled = true
                     ) {
                         content = it.lowercase()
                     }

--- a/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
@@ -39,7 +39,6 @@ import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
@@ -73,6 +72,7 @@ import moe.apex.rule34.util.MEDIUM_SPACER
 import moe.apex.rule34.util.TitleSummary
 import moe.apex.rule34.util.exportData
 import moe.apex.rule34.util.importData
+import moe.apex.rule34.util.launchInDefaultBrowser
 import moe.apex.rule34.util.preImportChecks
 import moe.apex.rule34.util.saveUriToPref
 import moe.apex.rule34.util.showToast
@@ -600,7 +600,7 @@ private fun AuthDialog(
     var userId by remember { mutableStateOf(default?.user ?: "") }
     var apiKey by remember { mutableStateOf(default?.apiKey ?: "") }
 
-    val uriHandler = LocalUriHandler.current
+    val context = LocalContext.current
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
@@ -632,7 +632,7 @@ private fun AuthDialog(
                                 SpanStyle(color = MaterialTheme.colorScheme.secondary, textDecoration = TextDecoration.Underline)
                             )
                         ) {
-                            uriHandler.openUri(url)
+                            launchInDefaultBrowser(context, url)
                         }
 
                         withLink(link) {

--- a/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
@@ -610,7 +610,6 @@ private fun AuthDialog(
                 PreferenceTextBox(
                     value = userId,
                     label = "User ID/name",
-                    keyboardType = KeyboardType.Password,
                     obscured = false
                 ) {
                     userId = it.trim()

--- a/app/src/main/java/moe/apex/rule34/preferences/PreferencesUI.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/PreferencesUI.kt
@@ -306,6 +306,7 @@ fun PreferenceTextBox(
     value: String,
     label: String,
     keyboardType: KeyboardType = KeyboardType.Text,
+    autoCorrectEnabled: Boolean = false,
     obscured: Boolean = false,
     onValueChange: (String) -> Unit,
 ) {
@@ -314,7 +315,7 @@ fun PreferenceTextBox(
         onValueChange = onValueChange,
         label = { Text(label, style = LocalTextStyle.current.copy(fontSize = (LocalTextStyle.current.fontSize.value - 3).sp)) },
         singleLine = true,
-        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+        keyboardOptions = KeyboardOptions(keyboardType = keyboardType, autoCorrectEnabled = autoCorrectEnabled),
         visualTransformation = if (obscured) {
             VisualTransformation { input ->
                 TransformedText(

--- a/app/src/main/java/moe/apex/rule34/util/Intents.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Intents.kt
@@ -3,7 +3,15 @@ package moe.apex.rule34.util
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
 import androidx.core.net.toUri
+
+
+fun getDefaultPackageForIntent(packageManager: PackageManager, intent: Intent): String? {
+    val resolveInfo = packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY)
+    return resolveInfo?.activityInfo?.packageName
+}
 
 
 fun openUrl(context: Context, url: String) {
@@ -15,4 +23,17 @@ fun openUrl(context: Context, url: String) {
     } catch (_: ActivityNotFoundException) {
         showToast(context, "Unable to open link.")
     }
+}
+
+
+fun createViewIntent(uri: Uri, targetPackage: String? = null): Intent {
+    return Intent(Intent.ACTION_VIEW, uri).apply {
+        flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        targetPackage?.let { setPackage(it) }
+    }
+}
+
+
+fun createDefaultBrowserIntent(): Intent {
+    return Intent(Intent.ACTION_VIEW, "http://example.com".toUri())
 }

--- a/app/src/main/java/moe/apex/rule34/util/Uri.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Uri.kt
@@ -1,0 +1,25 @@
+package moe.apex.rule34.util
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.net.toUri
+
+
+fun launchUriWithPackage(context: Context, uri: Uri, packageName: String) {
+    val launchIntent = createViewIntent(uri, packageName)
+    context.startActivity(launchIntent)
+}
+
+
+fun launchInDefaultBrowser(context: Context, url: String) {
+    launchInDefaultBrowser(context, url.toUri())
+}
+
+
+fun launchInDefaultBrowser(context: Context, uri: Uri) {
+    val defaultBrowserIntent = createDefaultBrowserIntent()
+    val defaultPackage = getDefaultPackageForIntent(context.packageManager, defaultBrowserIntent)
+    defaultPackage?.let {
+        launchUriWithPackage(context, uri, it)
+    } ?: showToast(context, "No browser found to handle URI: $uri")
+}

--- a/app/src/main/java/moe/apex/rule34/viewmodel/SearchResultsViewModel.kt
+++ b/app/src/main/java/moe/apex/rule34/viewmodel/SearchResultsViewModel.kt
@@ -33,7 +33,8 @@ class SearchResultsViewModel : ViewModel(), GridStateHolder by GridStateHolderDe
         if (isReady) {
             return
         }
-        Log.i("SearchResults", "Setting up SearchResultsViewModel with source: ${imageSource.name}, auth: $auth, tags: $tags")
+        val authProvided = auth != null
+        Log.i("SearchResults", "Setting up SearchResultsViewModel with source: ${imageSource.name}, authenticated: $authProvided, tags: $tags")
         this.imageSource = imageSource
         this.auth = auth
         query = imageSource.imageBoard.formatTagNameString(tags)


### PR DESCRIPTION
Updates the app to version 3.0.5.
### This has the following changes
- Adds more robust handling for deep links to fix the following issues:
  - The 'Find your credentials' button could cause a loop of infinitely launching DeepLinkActivity if the deep links for Danbooru and Gelbooru were enabled.
  - A crash that could happen when you open an unsupported imageboard link in Breadboard from Android's long-press menu (from Android System Intelligence).
- Fix Rule34 searching/recommendations (it now also requires auth, ugh)