### PR TITLE
3.0.7

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
         applicationId "moe.apex.breadboard"
         minSdk 26
         targetSdk 36
-        versionCode 305
-        versionName "3.0.5"
+        versionCode 306
+        versionName "3.0.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,8 +20,8 @@ android {
         applicationId "moe.apex.breadboard"
         minSdk 26
         targetSdk 36
-        versionCode 306
-        versionName "3.0.6"
+        versionCode 307
+        versionName "3.0.7"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,12 @@ plugins {
     id 'com.mikepenz.aboutlibraries.plugin'
 }
 
+
+Properties properties = new Properties()
+if (rootProject.file("local.properties").exists()) {
+    properties.load(rootProject.file("local.properties").newDataInputStream())
+}
+
 android {
     namespace 'moe.apex.rule34'
     compileSdk 36
@@ -21,6 +27,8 @@ android {
         vectorDrawables {
             useSupportLibrary true
         }
+
+        buildConfigField "String", "R34_APP_ID", properties.getProperty("R34_APP_ID", "\"\"")
     }
 
     buildTypes {
@@ -29,6 +37,10 @@ android {
             shrinkResources false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.debug
+            buildConfigField "String", "R34_API_KEY", properties.getProperty("R34_API_KEY", "\"\"")
+        }
+        debug {
+            buildConfigField "String", "R34_API_KEY", properties.getProperty("R34_API_KEY_DEBUG", "\"\"")
         }
     }
     compileOptions {

--- a/app/src/main/java/moe/apex/rule34/DeepLinkActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/DeepLinkActivity.kt
@@ -30,7 +30,7 @@ import moe.apex.rule34.viewmodel.BreadboardViewModel
 import moe.apex.rule34.util.FlagSecureHelper
 import moe.apex.rule34.util.createViewIntent
 import moe.apex.rule34.util.getDefaultPackageForIntent
-import moe.apex.rule34.util.launchInDefaultBrowser
+import moe.apex.rule34.util.launchInWebBrowser
 import moe.apex.rule34.util.launchUriWithPackage
 
 
@@ -70,7 +70,7 @@ class DeepLinkActivity : SingletonImageLoader.Factory, ComponentActivity() {
                             ImageView.fromUri(uri)?.let {
                                 navController.popBackStack()
                                 navController.navigate(it)
-                            } ?: openInBrowser(newIntent)
+                            } ?: reopenInBrowser(newIntent)
                         }
                     }
                     addOnNewIntentListener(listener)
@@ -83,14 +83,14 @@ class DeepLinkActivity : SingletonImageLoader.Factory, ComponentActivity() {
                             viewModel = viewModel,
                             startDestination = iv
                         )
-                    } ?: openInBrowser(intent)
+                    } ?: reopenInBrowser(intent)
                 } ?: finish()
             }
         }
     }
 
 
-    private fun openInBrowser(intent: Intent) {
+    private fun reopenInBrowser(intent: Intent) {
         val uri = intent.data!!
 
         // Not all apps set this but some like Chrome and Firefox do. We should use it if available.
@@ -113,7 +113,7 @@ class DeepLinkActivity : SingletonImageLoader.Factory, ComponentActivity() {
         referrer?.takeIf { it.scheme == "android-app" }?.host?.let { attemptingPackage ->
             // If the referrer is Breadboard itself but we already know Breadboard can't handle the link in-app, we shouldn't try to do so.
             if (attemptingPackage == BuildConfig.APPLICATION_ID) {
-                Log.w("openInBrowser", "Intent came from Breadboard itself but Breadboard can't handle URI $uri. If the intention was to open in the browser, call launchInDefaultBrowser() instead.")
+                Log.w("openInBrowser", "Intent came from Breadboard itself but Breadboard can't handle URI $uri. If the intention was to open in the browser, call launchInWebBrowser() instead.")
                 return@let
             }
             val relaunchIntent = createViewIntent(uri, attemptingPackage)
@@ -125,7 +125,7 @@ class DeepLinkActivity : SingletonImageLoader.Factory, ComponentActivity() {
         }
 
         // If all else fails, just open in the default browser.
-        launchInDefaultBrowser(this, uri)
+        launchInWebBrowser(this, uri)
         finishAndRemoveTask()
     }
 }

--- a/app/src/main/java/moe/apex/rule34/MainActivity.kt
+++ b/app/src/main/java/moe/apex/rule34/MainActivity.kt
@@ -90,7 +90,7 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity() {
             LaunchedEffect(prefs.imageSource, prefs.imageBoardAuths, prefs.filterRatingsLocally, prefs.blockedTags, prefs.recommendAllRatings) {
                 if (
                     viewModel.recommendationsProvider?.imageSource != prefs.imageSource ||
-                    viewModel.recommendationsProvider?.auth != prefs.authFor(prefs.imageSource) ||
+                    viewModel.recommendationsProvider?.auth != prefs.authFor(prefs.imageSource, applicationContext) ||
                     viewModel.recommendationsProvider?.filterRatingsLocally != prefs.filterRatingsLocally ||
                     viewModel.recommendationsProvider?.blockedTags != prefs.blockedTags ||
                     viewModel.recommendationsProvider?.showAllRatings != prefs.recommendAllRatings

--- a/app/src/main/java/moe/apex/rule34/detailview/ImageGrid.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/ImageGrid.kt
@@ -76,7 +76,7 @@ fun ImageGrid(
     filterComposable: (@Composable () -> Unit)? = null,
     pullToRefreshController: PullToRefreshController? = null,
     doneInitialLoad: Boolean = true,
-    onEndReached: suspend () -> Unit = { }
+    onEndReached: (suspend () -> Unit)? = null
 ) {
     val prefs = LocalPreferences.current
 
@@ -140,6 +140,14 @@ fun ImageGrid(
                     .fillMaxWidth()
             )
         }
+
+        LaunchedEffect(doneInitialLoad) {
+            if (doneInitialLoad) {
+                staggeredGridState.requestScrollToItem(0)
+                uniformGridState.requestScrollToItem(0)
+                println("done")
+            }
+        }
     }
 }
 
@@ -154,7 +162,7 @@ private fun StaggeredImageGrid(
     images: List<Image>,
     noImagesContent: @Composable () -> Unit,
     onImageClick: (Int, Image) -> Unit,
-    onEndReached: suspend () -> Unit = { }
+    onEndReached: (suspend () -> Unit)? = null
 ) {
     LazyVerticalStaggeredGrid(
         columns = StaggeredGridCells.Adaptive(MIN_CELL_WIDTH.dp),
@@ -165,22 +173,30 @@ private fun StaggeredImageGrid(
         verticalItemSpacing = SMALL_SPACER.dp
     ) {
         filterComposable?.let {
-            item(key = "ratings-filter", span = StaggeredGridItemSpan.FullLine ) { it() }
+            item(key = "ratings-filter", span = StaggeredGridItemSpan.FullLine ) {
+                it()
+            }
         }
 
         itemsIndexed(images, key = { _, image -> image.previewUrl }) { index, image ->
             StaggeredImagePreviewContainer(image, index, onImageClick)
         }
 
-        item { LaunchedEffect(Unit) { onEndReached() } }
+        onEndReached?.let {
+            item(key = "end-reached") {
+                LaunchedEffect(Unit) {
+                    it()
+                }
+            }
+        }
 
         if (images.isEmpty()) {
-            item(span = StaggeredGridItemSpan.FullLine) {
+            item(key = "no-images", span = StaggeredGridItemSpan.FullLine) {
                 noImagesContent()
             }
         }
 
-        item(span = StaggeredGridItemSpan.FullLine) {
+        item(key = "spacer", span = StaggeredGridItemSpan.FullLine) {
             NavBarHeightVerticalSpacer()
         }
     }
@@ -196,7 +212,7 @@ private fun UniformImageGrid(
     images: List<Image>,
     noImagesContent: @Composable () -> Unit,
     onImageClick: (Int, Image) -> Unit,
-    onEndReached: suspend () -> Unit = { }
+    onEndReached: (suspend () -> Unit)? = null
 ) {
     LazyVerticalGrid(
         columns = GridCells.Adaptive(MIN_CELL_WIDTH.dp),
@@ -207,22 +223,30 @@ private fun UniformImageGrid(
         verticalArrangement = Arrangement.spacedBy(SMALL_SPACER.dp)
     ) {
         filterComposable?.let {
-            item(span = { GridItemSpan(maxLineSpan) }) { it() }
+            item(key = "ratings-filter", span = { GridItemSpan(maxLineSpan) }) {
+                it()
+            }
         }
 
         itemsIndexed(images, key = { _, image -> image.previewUrl }) { index, image ->
             ImagePreviewContainer(image, index, onImageClick)
         }
 
-        item { LaunchedEffect(Unit) { onEndReached() } }
+        onEndReached?.let {
+            item(key = "end-reached") {
+                LaunchedEffect(Unit) {
+                    it()
+                }
+            }
+        }
 
         if (images.isEmpty()) {
-            item(span = { GridItemSpan(maxLineSpan) }) {
+            item(key = "no-images", span = { GridItemSpan(maxLineSpan) }) {
                 noImagesContent()
             }
         }
 
-        item(span = { GridItemSpan(maxLineSpan) }) {
+        item(key = "spacer", span = { GridItemSpan(maxLineSpan) }) {
             NavBarHeightVerticalSpacer()
         }
     }

--- a/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
+++ b/app/src/main/java/moe/apex/rule34/detailview/SearchResults.kt
@@ -50,6 +50,7 @@ fun SearchResults(navController: NavController, source: ImageSource, tagList: Li
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(topAppBarState)
     val shouldShowLargeImage = remember { mutableStateOf(false) }
     var initialPage by remember { mutableIntStateOf(0) }
+    val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
     val prefs = LocalPreferences.current
@@ -61,7 +62,7 @@ fun SearchResults(navController: NavController, source: ImageSource, tagList: Li
         if (!viewModel.isReady) {
             viewModel.setup(
                 imageSource = source,
-                auth = prefs.authFor(source),
+                auth = prefs.authFor(source, context),
                 tags = tagList
             )
         }

--- a/app/src/main/java/moe/apex/rule34/home/HomeScreen.kt
+++ b/app/src/main/java/moe/apex/rule34/home/HomeScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import moe.apex.rule34.detailview.ImageGrid
@@ -47,6 +48,7 @@ fun HomeScreen(
     viewModel: BreadboardViewModel,
     bottomBarVisibleState: MutableState<Boolean>,
 ) {
+    val context = LocalContext.current
     val prefs = LocalPreferences.current
     val topAppBarState = rememberTopAppBarState()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(topAppBarState)
@@ -57,7 +59,7 @@ fun HomeScreen(
         viewModel.recommendationsProvider = RecommendationsProvider(
             seedImages = prefs.favouriteImages,
             imageSource = prefs.imageSource,
-            auth = prefs.authFor(prefs.imageSource),
+            auth = prefs.authFor(prefs.imageSource, context),
             showAllRatings = prefs.recommendAllRatings,
             filterRatingsLocally = prefs.filterRatingsLocally,
             blockedTags = prefs.blockedTags

--- a/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
+++ b/app/src/main/java/moe/apex/rule34/image/ImageBoard.kt
@@ -18,7 +18,7 @@ data class ImageBoardAuth(
 )
 
 
-enum class ImageBoardLocalFilterType {
+enum class ImageBoardRequirement {
     NOT_NEEDED,
     RECOMMENDED,
     REQUIRED
@@ -37,10 +37,10 @@ interface ImageBoard {
     val aiTagName: String
     val firstPageIndex: Int
         get() = 0
-    val canLoadUnauthenticated: Boolean
-        get() = true
-    val localFilterType: ImageBoardLocalFilterType
-        get() = ImageBoardLocalFilterType.NOT_NEEDED
+    val apiKeyRequirement: ImageBoardRequirement
+        get() = ImageBoardRequirement.NOT_NEEDED
+    val localFilterType: ImageBoardRequirement
+        get() = ImageBoardRequirement.NOT_NEEDED
 
     fun loadAutoComplete(searchString: String): List<TagSuggestion> {
         val suggestions = mutableListOf<TagSuggestion>()
@@ -184,7 +184,7 @@ object Rule34 : GelbooruBasedImageBoard {
     override val imageSearchUrl = "${baseUrl}index.php?page=dapi&json=1&s=post&q=index&limit=100&tags=%s&pid=%d"
     override val aiTagName = "ai_generated"
     override val apiKeyCreationUrl = "https://rule34.xxx/index.php?page=account&s=options"
-    override val canLoadUnauthenticated = false
+    override val apiKeyRequirement = ImageBoardRequirement.NOT_NEEDED
 
     override fun parseImage(e: JSONObject): Image? {
         return parseImage(e, ImageSource.R34)
@@ -228,7 +228,7 @@ object Gelbooru : GelbooruBasedImageBoard {
     override val imageSearchUrl = "${baseUrl}index.php?page=dapi&json=1&s=post&q=index&limit=100&tags=%s&pid=%d"
     override val apiKeyCreationUrl = "${baseUrl}index.php?page=account&s=options"
     override val aiTagName = "ai-generated"
-    override val canLoadUnauthenticated = false
+    override val apiKeyRequirement = ImageBoardRequirement.REQUIRED
 
     override fun parseImage(e: JSONObject): Image? {
         return parseImage(e, ImageSource.GELBOORU)
@@ -259,8 +259,8 @@ object Danbooru : ImageBoard {
     override val firstPageIndex = 1
     override val authenticatedImageSearchUrl = "$imageSearchUrl&api_key=%s&login=%s"
     override val apiKeyCreationUrl = "${baseUrl}/profile"
-    override val canLoadUnauthenticated = false // Technically it can, it's just very limited
-    override val localFilterType = ImageBoardLocalFilterType.RECOMMENDED
+    override val apiKeyRequirement = ImageBoardRequirement.RECOMMENDED
+    override val localFilterType = ImageBoardRequirement.RECOMMENDED
 
     override fun parseImage(e: JSONObject): Image? {
         if (e.isNull("md5")) return null
@@ -357,7 +357,7 @@ object Yandere : ImageBoard {
     override val imageSearchUrl = "${baseUrl}post.json?tags=%s&page=%d&limit=100"
     override val aiTagName = "ai-generated" // Yande.re does not allow AI-generated images but this tag appears in search
     override val firstPageIndex = 1
-    override val localFilterType = ImageBoardLocalFilterType.REQUIRED
+    override val localFilterType = ImageBoardRequirement.REQUIRED
 
     override fun parseImage(e: JSONObject): Image? {
         if (e.isNull("md5")) return null

--- a/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/InfoSheet.kt
@@ -62,6 +62,7 @@ import moe.apex.rule34.util.TitledModalBottomSheet
 import moe.apex.rule34.util.copyText
 import moe.apex.rule34.util.isWebLink
 import moe.apex.rule34.util.largerShape
+import moe.apex.rule34.util.launchInWebBrowser
 import moe.apex.rule34.util.navBarHeight
 import moe.apex.rule34.util.openUrl
 import moe.apex.rule34.util.pluralise
@@ -210,7 +211,7 @@ fun InfoSheet(navController: NavController, image: Image, onDismissRequest: () -
                             TitleSummary(
                                 title = title,
                                 summary = it,
-                                onClick = { openUrl(context, it) },
+                                onClick = { launchInWebBrowser(context, it) }, // Breadboard can handle yande.re direct image links. We'll forcibly use the browser here to prevent that here.
                                 trailingIcon = {
                                     CopyIcon(title) {
                                         scope.launch { copyText(context, clip, it) }

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -134,10 +134,7 @@ fun LargeImageView(
     var storageLocationPromptLaunched by remember { mutableStateOf(false) }
 
     val isFullyZoomedOut by remember { derivedStateOf { zoomState.zoomFraction == 0f } }
-    val isMostlyZoomedOut by remember { derivedStateOf { zoomState.zoomFraction.let {
-        if (it == null) false
-        else it < 0.10
-    } } }
+    val isMostlyZoomedOut by remember { derivedStateOf { zoomState.zoomFraction.let { it == null || it < 0.10 } } }
 
     if (allImages.isEmpty()) {
         visible?.value = false
@@ -290,7 +287,9 @@ fun LargeImageView(
 
     if (showInfoSheet) {
         key(currentImage) {
-            InfoSheet(navController, currentImage, { showInfoSheet = false })
+            InfoSheet(navController, currentImage) {
+                showInfoSheet = false
+            }
         }
     }
 

--- a/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
+++ b/app/src/main/java/moe/apex/rule34/largeimageview/LargeImageView.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -288,7 +289,9 @@ fun LargeImageView(
     )
 
     if (showInfoSheet) {
-        InfoSheet(navController, currentImage, { showInfoSheet = false })
+        key(currentImage) {
+            InfoSheet(navController, currentImage, { showInfoSheet = false })
+        }
     }
 
     LaunchedEffect(visible?.value) {

--- a/app/src/main/java/moe/apex/rule34/navigation/Navigation.kt
+++ b/app/src/main/java/moe/apex/rule34/navigation/Navigation.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -59,6 +60,7 @@ import moe.apex.rule34.viewmodel.BreadboardViewModel
 
 @Composable
 fun Navigation(navController: NavHostController, viewModel: BreadboardViewModel, startDestination: Any = Search) {
+    val context = LocalContext.current
     val density = LocalDensity.current
     val prefs = LocalPreferences.current
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
@@ -210,7 +212,7 @@ fun Navigation(navController: NavHostController, viewModel: BreadboardViewModel,
                 ) {
                     composable<ImageView> {
                         val args = it.toRoute<ImageView>()
-                        LazyLargeImageView(navController) { args.source.imageBoard.loadImage(args.id, prefs.authFor(args.source)) }
+                        LazyLargeImageView(navController) { args.source.imageBoard.loadImage(args.id, prefs.authFor(args.source, context)) }
                     }
                     composable<Home> { HomeScreen(navController, viewModel, bottomBarVisibleState) }
                     composable<Search> { SearchScreen(navController, focusRequester, viewModel) }

--- a/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
@@ -72,7 +72,7 @@ import moe.apex.rule34.util.MEDIUM_SPACER
 import moe.apex.rule34.util.TitleSummary
 import moe.apex.rule34.util.exportData
 import moe.apex.rule34.util.importData
-import moe.apex.rule34.util.launchInDefaultBrowser
+import moe.apex.rule34.util.launchInWebBrowser
 import moe.apex.rule34.util.preImportChecks
 import moe.apex.rule34.util.saveUriToPref
 import moe.apex.rule34.util.showToast
@@ -630,7 +630,7 @@ private fun AuthDialog(
                                 SpanStyle(color = MaterialTheme.colorScheme.secondary, textDecoration = TextDecoration.Underline)
                             )
                         ) {
-                            launchInDefaultBrowser(context, url)
+                            launchInWebBrowser(context, url)
                         }
 
                         withLink(link) {

--- a/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
@@ -53,7 +53,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import moe.apex.rule34.image.ImageBoard
 import moe.apex.rule34.image.ImageBoardAuth
-import moe.apex.rule34.image.ImageBoardLocalFilterType
+import moe.apex.rule34.image.ImageBoardRequirement
 import moe.apex.rule34.navigation.AboutSettings
 import moe.apex.rule34.navigation.BlockedTagsSettings
 import moe.apex.rule34.navigation.ExperimentalSettings
@@ -309,20 +309,19 @@ fun PreferencesScreen(navController: NavHostController, viewModel: BreadboardVie
                         )
                     }
                     item {
-                        val noAuthNeeded =
-                            currentSettings.imageSource.imageBoard.canLoadUnauthenticated
+                        val authType = currentSettings.imageSource.imageBoard.apiKeyRequirement
                         TitleSummary(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .animateContentSize(),
                             title = "Set API key",
-                            summary = if (!noAuthNeeded) {
-                                "${currentSettings.imageSource.label} requires an API key for the best experience. " +
-                                        "Tap to set."
+                            summary = if (authType != ImageBoardRequirement.NOT_NEEDED) {
+                                "${currentSettings.imageSource.label} requires an API key${if (authType == ImageBoardRequirement.RECOMMENDED) " for the best experience." else "."} " +
+                                "Tap to set."
                             } else {
                                 "${currentSettings.imageSource.label} does not require an API key."
                             },
-                            enabled = !noAuthNeeded
+                            enabled = authType != ImageBoardRequirement.NOT_NEEDED
                         ) {
                             showAuthDialog = true
                         }
@@ -556,7 +555,7 @@ fun PreferencesScreen(navController: NavHostController, viewModel: BreadboardVie
                 )
             }
 
-            if (currentSettings.imageSource.imageBoard.localFilterType != ImageBoardLocalFilterType.NOT_NEEDED) {
+            if (currentSettings.imageSource.imageBoard.localFilterType != ImageBoardRequirement.NOT_NEEDED) {
                 item {
                     InfoSection(
                         text = "Danbooru limits searches to 2 tags (which includes ratings) " +

--- a/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
+++ b/app/src/main/java/moe/apex/rule34/preferences/Preferences.kt
@@ -104,7 +104,7 @@ fun PreferencesScreen(navController: NavHostController, viewModel: BreadboardVie
     if (showAuthDialog) {
         AuthDialog(
             selectedBoard = currentSettings.imageSource.imageBoard,
-            default = currentSettings.authFor(currentSettings.imageSource),
+            default = currentSettings.authFor(currentSettings.imageSource, context),
             onDismissRequest = { showAuthDialog = false }
         ) { username, apiKey ->
             scope.launch {

--- a/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
+++ b/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
@@ -102,7 +102,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import moe.apex.rule34.R
 import moe.apex.rule34.history.SearchHistoryEntry
-import moe.apex.rule34.image.ImageBoardLocalFilterType
+import moe.apex.rule34.image.ImageBoardRequirement
 import moe.apex.rule34.image.ImageRating
 import moe.apex.rule34.navigation.Results
 import moe.apex.rule34.preferences.ImageSource
@@ -365,17 +365,21 @@ fun SearchScreen(navController: NavController, focusRequester: FocusRequester, v
 
         if (!prefs.ratingsFilter.containsAll(availableRatingsForSource(prefs.imageSource))) {
             if (
-                prefs.imageSource.imageBoard.localFilterType == ImageBoardLocalFilterType.REQUIRED &&
+                prefs.imageSource.imageBoard.localFilterType == ImageBoardRequirement.REQUIRED &&
                 !prefs.filterRatingsLocally
             ) {
                 return showToast(context, "Enable the 'Filter ratings locally' option to filter ratings on this source.")
             } else if (
-                prefs.imageSource.imageBoard.localFilterType == ImageBoardLocalFilterType.RECOMMENDED &&
+                prefs.imageSource.imageBoard.localFilterType == ImageBoardRequirement.RECOMMENDED &&
                 !prefs.filterRatingsLocally &&
                 prefs.authFor(prefs.imageSource) == null
             ) {
                 return showToast(context, "Set an API key or enable the 'Filter ratings locally' option to filter ratings on this source.")
             }
+        }
+
+        if (prefs.imageSource.imageBoard.apiKeyRequirement == ImageBoardRequirement.REQUIRED) {
+            return showToast(context, "Set an API key in Settings first.")
         }
 
         // Danbooru has the 2-tag limit and filtering by multiple negated tags simply does not work on Yande.re

--- a/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
+++ b/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
@@ -74,6 +74,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -243,8 +244,10 @@ fun SearchScreen(navController: NavController, focusRequester: FocusRequester, v
                        the query in the time between getting suggestions and displaying them will cause
                        the old suggestions to be displayed. */
                     if (cleanedSearchString.isEmpty()) return@launch
-                    mostRecentSuggestions.clear()
-                    mostRecentSuggestions.addAll(suggestions)
+                    Snapshot.withMutableSnapshot {
+                        mostRecentSuggestions.clear()
+                        mostRecentSuggestions.addAll(suggestions)
+                    }
                     shouldShowSuggestions = true
                 } catch (e: Exception) {
                     withContext(Dispatchers.Main) {

--- a/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
+++ b/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
@@ -223,7 +223,7 @@ fun SearchScreen(navController: NavController, focusRequester: FocusRequester, v
         if (
             tagChipList.size > 2 &&
             prefs.imageSource == ImageSource.DANBOORU &&
-            prefs.authFor(ImageSource.DANBOORU) == null
+            prefs.authFor(ImageSource.DANBOORU, context) == null
         ) {
             showToast(context, "Danbooru only supports up to 2 tags without an API key")
             return false
@@ -372,7 +372,7 @@ fun SearchScreen(navController: NavController, focusRequester: FocusRequester, v
             } else if (
                 prefs.imageSource.imageBoard.localFilterType == ImageBoardRequirement.RECOMMENDED &&
                 !prefs.filterRatingsLocally &&
-                prefs.authFor(prefs.imageSource) == null
+                prefs.authFor(prefs.imageSource, context) == null
             ) {
                 return showToast(context, "Set an API key or enable the 'Filter ratings locally' option to filter ratings on this source.")
             }

--- a/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
+++ b/app/src/main/java/moe/apex/rule34/search/SearchScreen.kt
@@ -379,7 +379,7 @@ fun SearchScreen(navController: NavController, focusRequester: FocusRequester, v
         }
 
         if (prefs.imageSource.imageBoard.apiKeyRequirement == ImageBoardRequirement.REQUIRED) {
-            return showToast(context, "Set an API key in Settings first.")
+            return showToast(context, "Add an API key in Settings to use ${prefs.imageSource.label}.")
         }
 
         // Danbooru has the 2-tag limit and filtering by multiple negated tags simply does not work on Yande.re

--- a/app/src/main/java/moe/apex/rule34/util/Intents.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Intents.kt
@@ -34,6 +34,6 @@ fun createViewIntent(uri: Uri, targetPackage: String? = null): Intent {
 }
 
 
-fun createDefaultBrowserIntent(): Intent {
+fun createWebBrowserIntent(): Intent {
     return Intent(Intent.ACTION_VIEW, "http://example.com".toUri())
 }

--- a/app/src/main/java/moe/apex/rule34/util/Recommendations.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Recommendations.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import moe.apex.rule34.image.Image
 import moe.apex.rule34.image.ImageBoardAuth
-import moe.apex.rule34.image.ImageBoardLocalFilterType
+import moe.apex.rule34.image.ImageBoardRequirement
 import moe.apex.rule34.image.ImageRating
 import moe.apex.rule34.preferences.ImageSource
 import moe.apex.rule34.viewmodel.GridStateHolderDelegate
@@ -110,7 +110,7 @@ class RecommendationsProvider(
             "Fetching recommended posts for tags: ${recommendedTags.joinToString(", ")} - page $pageNumber"
         )
         val filterRatingsLocally = filterRatingsLocally ||
-                imageSource.imageBoard.localFilterType == ImageBoardLocalFilterType.REQUIRED ||
+                imageSource.imageBoard.localFilterType == ImageBoardRequirement.REQUIRED ||
                 (imageSource == ImageSource.DANBOORU && auth == null)
 
         val searchQuery = if (filterRatingsLocally) {

--- a/app/src/main/java/moe/apex/rule34/util/Recommendations.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Recommendations.kt
@@ -1,13 +1,12 @@
 package moe.apex.rule34.util
 
-import android.annotation.SuppressLint
 import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.toMutableStateList
+import androidx.compose.runtime.snapshots.Snapshot
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import moe.apex.rule34.image.Image
@@ -19,7 +18,6 @@ import moe.apex.rule34.viewmodel.GridStateHolderDelegate
 import moe.apex.rule34.viewmodel.GridStateHolder
 
 
-@SuppressLint("MutableCollectionMutableState")
 class RecommendationsProvider(
     private val seedImages: List<Image>,
     val imageSource: ImageSource,
@@ -58,8 +56,7 @@ class RecommendationsProvider(
         )
     }
 
-    // Not great but it avoids the momentary period where the list is empty when doing a new search.
-    var recommendedImages by mutableStateOf(mutableStateListOf<Image>())
+    val recommendedImages = mutableStateListOf<Image>()
     var doneInitialLoad by mutableStateOf(false)
     private val recommendedTags = mutableListOf<String>()
     private var pageNumber by mutableIntStateOf(imageSource.imageBoard.firstPageIndex)
@@ -155,9 +152,12 @@ class RecommendationsProvider(
                     shouldKeepSearching = false
                 } else {
                     if (pageNumber == imageSource.imageBoard.firstPageIndex) {
-                        recommendedImages = wantedResults.toMutableStateList()
+                        Snapshot.withMutableSnapshot {
+                            recommendedImages.clear()
+                            recommendedImages.addAll(wantedResults)
+                        }
                     } else if (wantedResults.isNotEmpty()) {
-                        recommendedImages += wantedResults.filter { it !in recommendedImages }
+                        recommendedImages.addAll(wantedResults.filter { it !in recommendedImages })
                     }
                 }
                 pageNumber++

--- a/app/src/main/java/moe/apex/rule34/util/SecretsManager.kt
+++ b/app/src/main/java/moe/apex/rule34/util/SecretsManager.kt
@@ -1,0 +1,89 @@
+package moe.apex.rule34.util
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import moe.apex.rule34.BuildConfig
+import java.security.MessageDigest
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+
+@Suppress("DEPRECATION")
+object SecretsManager {
+    private var decryptedApiKey: String? = null
+
+    fun getApiKey(context: Context): String? {
+        if (decryptedApiKey != null) {
+            return decryptedApiKey
+        }
+
+        if (BuildConfig.DEBUG) {
+            return BuildConfig.R34_API_KEY
+        }
+
+        try {
+            val signatureHash = getSignatureHash(context)
+                ?: throw SecurityException("Could not retrieve signature hash.")
+
+            val encryptedApiKey = BuildConfig.R34_API_KEY
+            if (encryptedApiKey.isEmpty()) {
+                throw IllegalArgumentException("API key not found in BuildConfig.")
+            }
+
+            val secretKeyBytes = Base64.getDecoder().decode(signatureHash)
+            val secretKey = SecretKeySpec(secretKeyBytes.copyOf(16), "AES")
+
+            val encryptedData = Base64.getDecoder().decode(encryptedApiKey)
+
+            val iv = encryptedData.copyOfRange(0, 12)
+            val encryptedApiKeyBytes = encryptedData.copyOfRange(12, encryptedData.size)
+
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            val gcmParameterSpec = GCMParameterSpec(128, iv)
+
+            cipher.init(Cipher.DECRYPT_MODE, secretKey, gcmParameterSpec)
+            val decryptedBytes = cipher.doFinal(encryptedApiKeyBytes)
+            val decryptedKey = String(decryptedBytes)
+
+            decryptedApiKey = decryptedKey
+            return decryptedKey
+
+        } catch (e: Exception) {
+            Log.e("SecretsManager", "Failed to get R34 key.", e)
+            return ""
+        }
+    }
+
+    private fun getSignatureHash(context: Context): String? {
+        return try {
+            val packageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                context.packageManager.getPackageInfo(
+                    context.packageName,
+                    PackageManager.PackageInfoFlags.of(PackageManager.GET_SIGNING_CERTIFICATES.toLong())
+                )
+            } else {
+                context.packageManager.getPackageInfo(
+                    context.packageName,
+                    PackageManager.GET_SIGNATURES
+                )
+            }
+
+            val signatures = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                packageInfo.signingInfo!!.apkContentsSigners
+            } else {
+                packageInfo.signatures
+            }
+
+            val signature = signatures!!.first().toByteArray()
+            val md = MessageDigest.getInstance("SHA-256")
+            val digest = md.digest(signature)
+            Base64.getEncoder().encodeToString(digest)
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/moe/apex/rule34/util/Storage.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Storage.kt
@@ -62,6 +62,9 @@ fun StorageLocationSelection(
             if (result.resultCode == RESULT_OK) {
                 val selectedUri = result.data?.data
                 if (selectedUri != null) {
+                    val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                                Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                    context.contentResolver.takePersistableUriPermission(selectedUri, flags)
                     onSuccess(selectedUri)
                 }
             } else {

--- a/app/src/main/java/moe/apex/rule34/util/Uri.kt
+++ b/app/src/main/java/moe/apex/rule34/util/Uri.kt
@@ -5,21 +5,31 @@ import android.net.Uri
 import androidx.core.net.toUri
 
 
-fun launchUriWithPackage(context: Context, uri: Uri, packageName: String) {
+fun launchUriWithPackage(context: Context, uri: Uri, packageName: String?) {
     val launchIntent = createViewIntent(uri, packageName)
     context.startActivity(launchIntent)
 }
 
 
-fun launchInDefaultBrowser(context: Context, url: String) {
-    launchInDefaultBrowser(context, url.toUri())
+fun launchInWebBrowser(context: Context, url: String) {
+    launchInWebBrowser(context, url.toUri())
 }
 
 
-fun launchInDefaultBrowser(context: Context, uri: Uri) {
-    val defaultBrowserIntent = createDefaultBrowserIntent()
-    val defaultPackage = getDefaultPackageForIntent(context.packageManager, defaultBrowserIntent)
+fun launchInWebBrowser(context: Context, uri: Uri) {
+    val webBrowserIntent = createWebBrowserIntent()
+    var defaultPackage = getDefaultPackageForIntent(context.packageManager, webBrowserIntent)
+
     defaultPackage?.let {
-        launchUriWithPackage(context, uri, it)
-    } ?: showToast(context, "No browser found to handle URI: $uri")
+        /* Older Android versions allow the user to not have a default browser set, even if they do
+           have browsers installed. In such cases, the "Open with" chooser will be opened.
+           This apparently uses the package name "android", but if we try and launch that package,
+           it won't work.
+           Instead, we'll set the package to null and let the chooser open naturally. */
+        if (it == "android") {
+            defaultPackage = null
+        }
+    } ?: return showToast(context, "No browser found")
+
+    launchUriWithPackage(context, uri, defaultPackage)
 }

--- a/app/src/main/java/moe/apex/rule34/viewmodel/FavouritesViewModel.kt
+++ b/app/src/main/java/moe/apex/rule34/viewmodel/FavouritesViewModel.kt
@@ -1,8 +1,6 @@
 package moe.apex.rule34.viewmodel
 
-import android.annotation.SuppressLint
 import androidx.lifecycle.ViewModel
 
 
-@SuppressLint("MutableCollectionMutableState")
 class FavouritesViewModel : GridStateHolder by GridStateHolderDelegate(), ViewModel()

--- a/app/src/main/java/moe/apex/rule34/viewmodel/GridStateController.kt
+++ b/app/src/main/java/moe/apex/rule34/viewmodel/GridStateController.kt
@@ -2,6 +2,9 @@ package moe.apex.rule34.viewmodel
 
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 
 
 interface GridStateHolder {
@@ -16,6 +19,6 @@ interface GridStateHolder {
 
 
 class GridStateHolderDelegate : GridStateHolder {
-    override var staggeredGridState = LazyStaggeredGridState()
-    override var uniformGridState = LazyGridState()
+    override var staggeredGridState by mutableStateOf(LazyStaggeredGridState())
+    override var uniformGridState by mutableStateOf(LazyGridState())
 }

--- a/app/src/main/java/moe/apex/rule34/viewmodel/SearchResultsViewModel.kt
+++ b/app/src/main/java/moe/apex/rule34/viewmodel/SearchResultsViewModel.kt
@@ -1,13 +1,12 @@
 package moe.apex.rule34.viewmodel
 
-import android.annotation.SuppressLint
 import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.toMutableStateList
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -16,12 +15,10 @@ import moe.apex.rule34.image.ImageBoardAuth
 import moe.apex.rule34.preferences.ImageSource
 
 
-@SuppressLint("MutableCollectionMutableState")
 class SearchResultsViewModel : ViewModel(), GridStateHolder by GridStateHolderDelegate() {
     var isReady by mutableStateOf(false)
     var doneInitialLoad by mutableStateOf(false)
-    // Not great but it avoids the momentary period where the list is empty when doing a new search.
-    var images by mutableStateOf(mutableStateListOf<Image>())
+    val images = mutableStateListOf<Image>()
     private var shouldKeepSearching by mutableStateOf(true)
     private var pageNumber by mutableIntStateOf(0) // We'll set this to the proper value later
     private var auth: ImageBoardAuth? = null
@@ -66,7 +63,10 @@ class SearchResultsViewModel : ViewModel(), GridStateHolder by GridStateHolderDe
                     shouldKeepSearching = false
                 } else {
                     if (pageNumber == imageSource.imageBoard.firstPageIndex) {
-                        images = newImages.toMutableStateList()
+                        Snapshot.withMutableSnapshot {
+                            images.clear()
+                            images.addAll(newImages)
+                        }
                     } else {
                         images += newImages.filter { it !in images }
                     }


### PR DESCRIPTION
Updates the app to version 3.0.7.
### This has the following changes
- The user is no longer required to add an API key for R34.
- Breadboard now clarifies when an API key is *required* vs *recommended*.
- Breadboard will now disallow searching on sources where keys are required but are not provided to prevent confusion.
- Breadboard will (finally) actually remember the download location you set.
- General crash fixes and bug fixes.