### PR TITLE
Support sharing images to reverse search

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <intent-filter>
+            <intent-filter android:label="SauceNao">
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,12 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".DeepLinkActivity"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <!-- android:configChanges="uiMode" is added to prevent the activity from recreating itself
+         during night mode change, avoiding unnecessary state resets wherever possible.
+
+         android:documentLaunchMode="intoExisting" is added to prevent the activity from stacking
+         on top of the current app while sharing images (if no existing instance of Breadboard was
+         found) on older Android versions. -->
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -12,17 +18,15 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Breadboard"
         android:windowSoftInputMode="adjustResize"
-        android:enableOnBackInvokedCallback="true">
+        android:enableOnBackInvokedCallback="true"
+        android:configChanges="uiMode"
+        android:documentLaunchMode="intoExisting">
         <activity
             android:name=".MainActivity"
             android:launchMode="singleTop"
             android:taskAffinity="moe.apex.breadboard.MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.Breadboard"
-            android:configChanges="uiMode"> <!-- Add "uiMode" to "configChanges" to prevent the
-                                                 activity from recreating itself during night mode
-                                                 change, avoiding unnecessary state resets wherever
-                                                 possible. -->
+            android:theme="@style/Theme.Breadboard">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -39,8 +43,7 @@
             android:taskAffinity="moe.apex.breadboard.DeepLinkActivity"
             android:launchMode="singleTop"
             android:exported="true"
-            android:theme="@style/Theme.Breadboard"
-            android:configChanges="uiMode">
+            android:theme="@style/Theme.Breadboard">
 
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <intent-filter android:label="SauceNao">
+            <intent-filter android:label="SauceNAO">
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="image/*" />

--- a/app/src/main/java/moe/apex/breadboard/MainActivity.kt
+++ b/app/src/main/java/moe/apex/breadboard/MainActivity.kt
@@ -187,13 +187,10 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
     private fun createReverseSearchIntent(intent: Intent): Intent? {
         if (intent.action != Intent.ACTION_SEND) return null
 
+        intent.putExtra("destination", "reverse_search")
+
         val initialImageUrl = intent.extras?.getString(Intent.EXTRA_TEXT)
         val initialFileUri = intent.clipData?.getItemAt(0)?.uri
-
-        val intent = Intent(Intent.ACTION_VIEW)
-        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        intent.component = ComponentName(this, MainActivity::class.java)
-        intent.putExtra("destination", "reverse_search")
 
         /* Sometimes a shared link may contain an image clipData of the favicon, so we must
            prioritize the text over the clipData. Providing them both would be bad. */

--- a/app/src/main/java/moe/apex/breadboard/MainActivity.kt
+++ b/app/src/main/java/moe/apex/breadboard/MainActivity.kt
@@ -76,13 +76,6 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
     }
 
 
-    private fun maybePrepareArtistDestination(intent: Intent): ArtistProfile? {
-        val artist = intent.getStringExtra("artist") ?: return null
-        val source = ImageSource.valueOf(intent.getStringExtra("origin_source") ?: return null)
-        return ArtistProfile(artist, source)
-    }
-
-
     private fun maybePrepareResultsDestination(intent: Intent): Results? {
         val searchSource = ImageSource.valueOf(intent.getStringExtra("source") ?: return null)
         val searchQuery = intent.getStringArrayExtra("query") ?: return null
@@ -90,8 +83,15 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
     }
 
 
+    private fun maybePrepareArtistDestination(intent: Intent): ArtistProfile? {
+        val artist = intent.getStringExtra("artist") ?: return null
+        val source = ImageSource.valueOf(intent.getStringExtra("origin_source") ?: return null)
+        return ArtistProfile(artist, source)
+    }
+
+
     private fun determineDestination(intent: Intent): Any? {
-        // Handle reverse search Intent.ACTION_SEND intent
+        // Handle Intent.ACTION_SEND intent for reverse search
         if (intent.action == Intent.ACTION_SEND) {
             /* Sometimes a shared link may contain an image clipData of the favicon, so we must
                prioritise the text over the clipData. Providing them both would be bad. */

--- a/app/src/main/java/moe/apex/breadboard/MainActivity.kt
+++ b/app/src/main/java/moe/apex/breadboard/MainActivity.kt
@@ -98,8 +98,12 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
 
 
     private fun determineDestination(intent: Intent): Any? {
-        // Transform any Intent.ACTION_SEND intent to a valid reverse search destination intent
-        if (intent.action == Intent.ACTION_SEND) transformReverseSearchDestinationIntent(intent)
+        val intent = if (intent.action == Intent.ACTION_SEND) {
+            // Transform any Intent.ACTION_SEND intent to a valid reverse search destination intent
+            createReverseSearchDestinationIntent(intent)
+        } else {
+            intent
+        }
 
         return when (intent.getStringExtra("destination")) {
             "artist" -> maybePrepareArtistDestination(intent)
@@ -184,7 +188,9 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
     }
 
 
-    private fun transformReverseSearchDestinationIntent(intent: Intent) {
+    private fun createReverseSearchDestinationIntent(intent: Intent): Intent {
+        val intent = Intent(intent)
+
         intent.putExtra("destination", "reverse_search")
 
         val initialImageUrl = intent.extras?.getString(Intent.EXTRA_TEXT)
@@ -197,5 +203,7 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
         } else if (initialFileUri != null) {
             intent.putExtra("initial_file_uri", initialFileUri.toString())
         }
+
+        return intent
     }
 }

--- a/app/src/main/java/moe/apex/breadboard/MainActivity.kt
+++ b/app/src/main/java/moe/apex/breadboard/MainActivity.kt
@@ -1,7 +1,6 @@
 package moe.apex.breadboard
 
 import android.app.UiModeManager
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build

--- a/app/src/main/java/moe/apex/breadboard/MainActivity.kt
+++ b/app/src/main/java/moe/apex/breadboard/MainActivity.kt
@@ -98,7 +98,8 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
 
 
     private fun determineDestination(intent: Intent): Any? {
-        val intent = createReverseSearchIntent(intent) ?: intent
+        // Transform any Intent.ACTION_SEND intent to a valid reverse search destination intent
+        if (intent.action == Intent.ACTION_SEND) transformReverseSearchIntent(intent)
 
         return when (intent.getStringExtra("destination")) {
             "artist" -> maybePrepareArtistDestination(intent)
@@ -183,9 +184,7 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
     }
 
 
-    private fun createReverseSearchIntent(intent: Intent): Intent? {
-        if (intent.action != Intent.ACTION_SEND) return null
-
+    private fun transformReverseSearchIntent(intent: Intent) {
         intent.putExtra("destination", "reverse_search")
 
         val initialImageUrl = intent.extras?.getString(Intent.EXTRA_TEXT)
@@ -198,7 +197,5 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
         } else if (initialFileUri != null) {
             intent.putExtra("initial_file_uri", initialFileUri.toString())
         }
-
-        return intent
     }
 }

--- a/app/src/main/java/moe/apex/breadboard/MainActivity.kt
+++ b/app/src/main/java/moe/apex/breadboard/MainActivity.kt
@@ -90,25 +90,23 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
     }
 
 
-    private fun maybePrepareReverseSearchDestination(intent: Intent): ReverseSearch? {
-        val initialImageUrl = intent.getStringExtra("initial_image_url")
-        val initialFileUri = intent.getStringExtra("initial_file_uri")
-        return ReverseSearch(initialImageUrl, initialFileUri)
-    }
-
-
     private fun determineDestination(intent: Intent): Any? {
-        val intent = if (intent.action == Intent.ACTION_SEND) {
-            // Transform any Intent.ACTION_SEND intent to a valid reverse search destination intent
-            createReverseSearchDestinationIntent(intent)
-        } else {
-            intent
+        // Handle reverse search Intent.ACTION_SEND intent
+        if (intent.action == Intent.ACTION_SEND) {
+            /* Sometimes a shared link may contain an image clipData of the favicon, so we must
+               prioritise the text over the clipData. Providing them both would be bad. */
+            intent.extras?.getString(Intent.EXTRA_TEXT)?.let { initialImageUrl ->
+                return ReverseSearch(initialImageUrl = initialImageUrl)
+            }
+
+            intent.clipData?.getItemAt(0)?.uri?.let { initialFileUri ->
+                return ReverseSearch(initialFileUri = initialFileUri.toString())
+            }
         }
 
         return when (intent.getStringExtra("destination")) {
             "artist" -> maybePrepareArtistDestination(intent)
             "search" -> maybePrepareResultsDestination(intent)
-            "reverse_search" -> maybePrepareReverseSearchDestination(intent)
             else -> null
         }
     }
@@ -185,25 +183,5 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
                 Navigation(navController, determineDestination(intent) ?: startDestination)
             }
         }
-    }
-
-
-    private fun createReverseSearchDestinationIntent(intent: Intent): Intent {
-        val intent = Intent(intent)
-
-        intent.putExtra("destination", "reverse_search")
-
-        val initialImageUrl = intent.extras?.getString(Intent.EXTRA_TEXT)
-        val initialFileUri = intent.clipData?.getItemAt(0)?.uri
-
-        /* Sometimes a shared link may contain an image clipData of the favicon, so we must
-           prioritise the text over the clipData. Providing them both would be bad. */
-        if (initialImageUrl != null) {
-            intent.putExtra("initial_image_url", initialImageUrl)
-        } else if (initialFileUri != null) {
-            intent.putExtra("initial_file_uri", initialFileUri.toString())
-        }
-
-        return intent
     }
 }

--- a/app/src/main/java/moe/apex/breadboard/MainActivity.kt
+++ b/app/src/main/java/moe/apex/breadboard/MainActivity.kt
@@ -99,12 +99,12 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
 
 
     private fun determineDestination(intent: Intent): Any? {
-        val newIntent = createReverseSearchIntent(intent) ?: intent
+        val intent = createReverseSearchIntent(intent) ?: intent
 
-        return when (newIntent.getStringExtra("destination")) {
-            "artist" -> maybePrepareArtistDestination(newIntent)
-            "search" -> maybePrepareResultsDestination(newIntent)
-            "reverse_search" -> maybePrepareReverseSearchDestination(newIntent)
+        return when (intent.getStringExtra("destination")) {
+            "artist" -> maybePrepareArtistDestination(intent)
+            "search" -> maybePrepareResultsDestination(intent)
+            "reverse_search" -> maybePrepareReverseSearchDestination(intent)
             else -> null
         }
     }

--- a/app/src/main/java/moe/apex/breadboard/MainActivity.kt
+++ b/app/src/main/java/moe/apex/breadboard/MainActivity.kt
@@ -99,7 +99,7 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
 
     private fun determineDestination(intent: Intent): Any? {
         // Transform any Intent.ACTION_SEND intent to a valid reverse search destination intent
-        if (intent.action == Intent.ACTION_SEND) transformReverseSearchIntent(intent)
+        if (intent.action == Intent.ACTION_SEND) transformReverseSearchDestinationIntent(intent)
 
         return when (intent.getStringExtra("destination")) {
             "artist" -> maybePrepareArtistDestination(intent)
@@ -184,14 +184,14 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
     }
 
 
-    private fun transformReverseSearchIntent(intent: Intent) {
+    private fun transformReverseSearchDestinationIntent(intent: Intent) {
         intent.putExtra("destination", "reverse_search")
 
         val initialImageUrl = intent.extras?.getString(Intent.EXTRA_TEXT)
         val initialFileUri = intent.clipData?.getItemAt(0)?.uri
 
         /* Sometimes a shared link may contain an image clipData of the favicon, so we must
-           prioritize the text over the clipData. Providing them both would be bad. */
+           prioritise the text over the clipData. Providing them both would be bad. */
         if (initialImageUrl != null) {
             intent.putExtra("initial_image_url", initialImageUrl)
         } else if (initialFileUri != null) {

--- a/app/src/main/java/moe/apex/breadboard/MainActivity.kt
+++ b/app/src/main/java/moe/apex/breadboard/MainActivity.kt
@@ -1,6 +1,7 @@
 package moe.apex.breadboard
 
 import android.app.UiModeManager
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -35,6 +36,7 @@ import moe.apex.breadboard.navigation.Favourites
 import moe.apex.breadboard.navigation.Home
 import moe.apex.breadboard.navigation.Navigation
 import moe.apex.breadboard.navigation.Results
+import moe.apex.breadboard.navigation.ReverseSearch
 import moe.apex.breadboard.navigation.Search
 import moe.apex.breadboard.preferences.DarkTheme
 import moe.apex.breadboard.preferences.ImageSource
@@ -75,13 +77,6 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
     }
 
 
-    private fun maybePrepareResultsDestination(intent: Intent): Results? {
-        val searchSource = ImageSource.valueOf(intent.getStringExtra("source") ?: return null)
-        val searchQuery = intent.getStringArrayExtra("query") ?: return null
-        return Results(searchSource, searchQuery.toList())
-    }
-
-
     private fun maybePrepareArtistDestination(intent: Intent): ArtistProfile? {
         val artist = intent.getStringExtra("artist") ?: return null
         val source = ImageSource.valueOf(intent.getStringExtra("origin_source") ?: return null)
@@ -89,10 +84,27 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
     }
 
 
+    private fun maybePrepareResultsDestination(intent: Intent): Results? {
+        val searchSource = ImageSource.valueOf(intent.getStringExtra("source") ?: return null)
+        val searchQuery = intent.getStringArrayExtra("query") ?: return null
+        return Results(searchSource, searchQuery.toList())
+    }
+
+
+    private fun maybePrepareReverseSearchDestination(intent: Intent): ReverseSearch? {
+        val initialImageUrl = intent.getStringExtra("initial_image_url")
+        val initialFileUri = intent.getStringExtra("initial_file_uri")
+        return ReverseSearch(initialImageUrl, initialFileUri)
+    }
+
+
     private fun determineDestination(intent: Intent): Any? {
-        return when (intent.getStringExtra("destination")) {
-            "artist" -> maybePrepareArtistDestination(intent)
-            "search" -> maybePrepareResultsDestination(intent)
+        val newIntent = createReverseSearchIntent(intent) ?: intent
+
+        return when (newIntent.getStringExtra("destination")) {
+            "artist" -> maybePrepareArtistDestination(newIntent)
+            "search" -> maybePrepareResultsDestination(newIntent)
+            "reverse_search" -> maybePrepareReverseSearchDestination(newIntent)
             else -> null
         }
     }
@@ -169,5 +181,28 @@ class MainActivity : SingletonImageLoader.Factory, ComponentActivity(), VolumeBu
                 Navigation(navController, determineDestination(intent) ?: startDestination)
             }
         }
+    }
+
+
+    private fun createReverseSearchIntent(intent: Intent): Intent? {
+        if (intent.action != Intent.ACTION_SEND) return null
+
+        val initialImageUrl = intent.extras?.getString(Intent.EXTRA_TEXT)
+        val initialFileUri = intent.clipData?.getItemAt(0)?.uri
+
+        val intent = Intent(Intent.ACTION_VIEW)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        intent.component = ComponentName(this, MainActivity::class.java)
+        intent.putExtra("destination", "reverse_search")
+
+        /* Sometimes a shared link may contain an image clipData of the favicon, so we must
+           prioritize the text over the clipData. Providing them both would be bad. */
+        if (initialImageUrl != null) {
+            intent.putExtra("initial_image_url", initialImageUrl)
+        } else if (initialFileUri != null) {
+            intent.putExtra("initial_file_uri", initialFileUri.toString())
+        }
+
+        return intent
     }
 }

--- a/app/src/main/java/moe/apex/breadboard/navigation/Destinations.kt
+++ b/app/src/main/java/moe/apex/breadboard/navigation/Destinations.kt
@@ -88,7 +88,7 @@ object FollowedArtists
 object Search
 
 @Serializable
-object ReverseSearch
+data class ReverseSearch(val initialImageUrl: String? = null, val initialFileUri: String? = null)
 
 @Serializable
 data class Results(

--- a/app/src/main/java/moe/apex/breadboard/navigation/Navigation.kt
+++ b/app/src/main/java/moe/apex/breadboard/navigation/Navigation.kt
@@ -202,8 +202,8 @@ fun Navigation(navController: NavHostController, startDestination: Any = Search)
                             },
                             onClick = {
                                 if (!currentRoute.routeIs(ReverseSearch::class)) {
-                                    navController.navigate(ReverseSearch) {
-                                        popUpTo(ReverseSearch) { inclusive = true }
+                                    navController.navigate(ReverseSearch()) {
+                                        popUpTo(ReverseSearch()) { inclusive = true }
                                     }
                                 }
                             }
@@ -288,7 +288,10 @@ fun Navigation(navController: NavHostController, startDestination: Any = Search)
                 }
                 composable<Home> { HomeScreen(navController) { isNavigationBarVisible = it } }
                 composable<Search> { SearchScreen(navController, focusRequester) }
-                composable<ReverseSearch> { ReverseSearchScreen(navController) }
+                composable<ReverseSearch> {
+                    val args = it.toRoute<ReverseSearch>()
+                    ReverseSearchScreen(navController, args.initialImageUrl, args.initialFileUri)
+                }
                 composable<Results> {
                     val args = it.toRoute<Results>()
                     SearchResults(navController, args.source, args.tags)

--- a/app/src/main/java/moe/apex/breadboard/saucenao/ReverseSearchScreen.kt
+++ b/app/src/main/java/moe/apex/breadboard/saucenao/ReverseSearchScreen.kt
@@ -214,6 +214,10 @@ fun ReverseSearchScreen(
                                             if (mimeType?.startsWith("image/") == true) {
                                                 selectedFileUri = uri
                                             } else {
+                                                /* onValueChange does not trigger when you press
+                                                   the paste button, so we still have to reset the
+                                                   selected file URI. */
+                                                selectedFileUri = null
                                                 imageUrl = clipboardItem.text.toString()
                                             }
                                         } else {

--- a/app/src/main/java/moe/apex/breadboard/saucenao/ReverseSearchScreen.kt
+++ b/app/src/main/java/moe/apex/breadboard/saucenao/ReverseSearchScreen.kt
@@ -80,14 +80,18 @@ import moe.apex.breadboard.util.showToast
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun ReverseSearchScreen(navController: NavController) {
+fun ReverseSearchScreen(
+    navController: NavController,
+    initialImageUrl: String? = null,
+    initialFileUri: String? = null
+) {
     val context = LocalContext.current
     val clipboard = LocalClipboard.current
     val prefs = LocalPreferences.current
     val scope = rememberCoroutineScope()
 
-    var imageUrl by rememberSaveable { mutableStateOf("") }
-    var selectedFileUri by rememberSaveable { mutableStateOf<Uri?>(null) }
+    var imageUrl by rememberSaveable { mutableStateOf(initialImageUrl ?: "") }
+    var selectedFileUri by rememberSaveable { mutableStateOf(initialFileUri?.toUri()) }
 
     val imagePickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()

--- a/app/src/main/java/moe/apex/breadboard/saucenao/ReverseSearchScreen.kt
+++ b/app/src/main/java/moe/apex/breadboard/saucenao/ReverseSearchScreen.kt
@@ -215,9 +215,9 @@ fun ReverseSearchScreen(
                                             if (mimeType?.startsWith("image/") == true) {
                                                 selectedFileUri = uri
                                             } else {
-                                                /* onValueChange does not trigger when you press
-                                                   the paste button, so we still have to reset the
-                                                   selected file URI. */
+                                                /* onValueChange does not trigger when you mutate
+                                                   imageUrl via code, so we still have to reset
+                                                   selectedFileUri here. */
                                                 selectedFileUri = null
                                                 imageUrl = clipboardItem.text.toString()
                                             }

--- a/app/src/main/java/moe/apex/breadboard/saucenao/ReverseSearchScreen.kt
+++ b/app/src/main/java/moe/apex/breadboard/saucenao/ReverseSearchScreen.kt
@@ -201,9 +201,10 @@ fun ReverseSearchScreen(
                             IconButton(
                                 onClick = {
                                     scope.launch {
-                                        val clipboardItem = clipboard.nativeClipboard.primaryClip?.getItemAt(
-                                            0
-                                        )
+                                        val clipboardItem =
+                                            clipboard.nativeClipboard.primaryClip?.getItemAt(
+                                                0
+                                            )
 
                                         if (clipboardItem != null) {
                                             val uri = clipboardItem.uri

--- a/app/src/main/java/moe/apex/breadboard/saucenao/ReverseSearchScreen.kt
+++ b/app/src/main/java/moe/apex/breadboard/saucenao/ReverseSearchScreen.kt
@@ -201,13 +201,21 @@ fun ReverseSearchScreen(
                             IconButton(
                                 onClick = {
                                     scope.launch {
-                                        val clipboardText =
-                                            clipboard.nativeClipboard.primaryClip?.getItemAt(
-                                                0
-                                            )?.text?.toString()
-                                        if (clipboardText != null) {
-                                            imageUrl = clipboardText
-                                            selectedFileUri = null
+                                        val clipboardItem = clipboard.nativeClipboard.primaryClip?.getItemAt(
+                                            0
+                                        )
+
+                                        if (clipboardItem != null) {
+                                            val uri = clipboardItem.uri
+                                            val mimeType = uri?.let {
+                                                context.contentResolver.getType(it)
+                                            }
+
+                                            if (mimeType?.startsWith("image/") == true) {
+                                                selectedFileUri = uri
+                                            } else {
+                                                imageUrl = clipboardItem.text.toString()
+                                            }
                                         } else {
                                             showToast(context, "Nothing on the clipboard")
                                         }


### PR DESCRIPTION
Resolves #60.

In addition:
- Sharing any image URL (or any plain text, for that matter; gotta validate the URLs eventually) would also have the app paste the URL into the input box
- The paste button next to the input box in the reverse search screen can now also paste an image from the clipboard, if applicable