### PR TITLE
Fix potential crash on bad clipboard item mime type

### DIFF
--- a/app/src/main/java/moe/apex/breadboard/saucenao/ReverseSearchScreen.kt
+++ b/app/src/main/java/moe/apex/breadboard/saucenao/ReverseSearchScreen.kt
@@ -205,24 +205,28 @@ fun ReverseSearchScreen(
                                             clipboard.nativeClipboard.primaryClip?.getItemAt(
                                                 0
                                             )
-
-                                        if (clipboardItem != null) {
-                                            val uri = clipboardItem.uri
-                                            val mimeType = uri?.let {
+                                        val mimeType =
+                                            clipboardItem?.uri?.let {
                                                 context.contentResolver.getType(it)
                                             }
 
-                                            if (mimeType?.startsWith("image/") == true) {
-                                                selectedFileUri = uri
-                                            } else {
+                                        if (mimeType?.startsWith("image/") == true) {
+                                            selectedFileUri = clipboardItem.uri
+                                        } else {
+                                            val clipboardText =
+                                                clipboardItem?.text?.toString()?.trim()?.takeIf {
+                                                    it.isNotEmpty()
+                                                }
+
+                                            if (clipboardText != null) {
                                                 /* onValueChange does not trigger when you mutate
                                                    imageUrl via code, so we still have to reset
                                                    selectedFileUri here. */
                                                 selectedFileUri = null
-                                                imageUrl = clipboardItem.text.toString()
+                                                imageUrl = clipboardText
+                                            } else {
+                                                showToast(context, "Nothing on the clipboard")
                                             }
-                                        } else {
-                                            showToast(context, "Nothing on the clipboard")
                                         }
                                     }
                                 }


### PR DESCRIPTION
A user might have an item copied to their clipboard that isn't necessarily an image. The current code always assumes that a text would exist if the copied item wasn't an image, but that's not always the case. This would lead to a crash due to the app calling `toString()` to a null value (`clipboardItem.text`).

This fixes that and also makes sure that the copied text isn't empty (or filled with whitespaces) before attempting to paste anything.